### PR TITLE
Fix: Data Wiring duplication check seems to not delete Date when moving/deleting Nodes

### DIFF
--- a/ros_bt_py/src/ros_bt_py/helpers.py
+++ b/ros_bt_py/src/ros_bt_py/helpers.py
@@ -33,7 +33,7 @@ import rclpy.logging
 import functools
 from collections import OrderedDict
 
-from ros_bt_py_interfaces.msg import CapabilityInterface
+from ros_bt_py_interfaces.msg import CapabilityInterface, Node, Tree
 from ros_bt_py.ros_helpers import EnumValue, LoggerLevel
 
 
@@ -81,6 +81,13 @@ def remove_input_output_values(tree):
             node_input.serialized_value = "null"
         for node_output in node.outputs:
             node_output.serialized_value = "null"
+    return tree
+
+
+def set_node_state_to_shutdown(tree):
+    """Set all node states to shutdown."""
+    for node in tree.nodes:
+        node.state = Node.SHUTDOWN
     return tree
 
 

--- a/ros_bt_py/src/ros_bt_py/package_manager.py
+++ b/ros_bt_py/src/ros_bt_py/package_manager.py
@@ -26,6 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import os
+from rclpy.logging import get_logger
 from ament_index_python import PackageNotFoundError
 from rclpy.utilities import ament_index_python
 
@@ -38,7 +39,7 @@ import rclpy.logging
 import rosidl_runtime_py
 import rosidl_runtime_py.utilities
 
-from ros_bt_py_interfaces.msg import Message, Messages, Package, Packages
+from ros_bt_py_interfaces.msg import Message, Messages, Package, Packages, Tree
 from ros_bt_py_interfaces.srv import (
     GetMessageFields,
     SaveTree,
@@ -51,6 +52,7 @@ from ros_bt_py.node import increment_name
 from ros_bt_py.helpers import (
     remove_input_output_values,
     json_encode,
+    set_node_state_to_shutdown,
 )
 from ros_bt_py.ros_helpers import get_message_constant_fields
 
@@ -103,6 +105,8 @@ class PackageManager(object):
         """
         # remove input and output values from nodes
         request.tree = remove_input_output_values(tree=request.tree)
+        request.tree = set_node_state_to_shutdown(tree=request.tree)
+        request.tree.state = Tree.IDLE
 
         if request.storage_path not in self.tree_storage_directory_paths:
             response.success = False

--- a/ros_bt_py/src/ros_bt_py/tree_manager.py
+++ b/ros_bt_py/src/ros_bt_py/tree_manager.py
@@ -1438,6 +1438,22 @@ class TreeManager:
             # If we're not removing the children, at least set their parent to None
             for child in self.nodes[request.node_name].children:
                 child.parent = None
+
+        # Unwire wirings that have removed nodes as source or target
+        self.unwire_data(
+            WireNodeData.Request(
+                wirings=[
+                    wiring
+                    for wiring in self.tree_msg.data_wirings
+                    if (
+                        wiring.source.node_name in names_to_remove
+                        or wiring.target.node_name in names_to_remove
+                    )
+                ]
+            ),
+            WireNodeData.Response(),
+        )
+
         # Remove nodes in the reverse order they were added to the
         # list, i.e. the "deepest" ones first. This ensures that the
         # parent we refer to in the error message still exists.
@@ -1469,21 +1485,6 @@ class TreeManager:
                 self.nodes[self.nodes[name].parent.name].remove_child(name)
             del self.nodes[name]
 
-        # Unwire wirings that have removed nodes as source or target
-        self.unwire_data(
-            WireNodeData.Request(
-                wirings=[
-                    wiring
-                    for wiring in self.tree_msg.data_wirings
-                    if (
-                        wiring.source.node_name in names_to_remove
-                        or wiring.target.node_name in names_to_remove
-                    )
-                ]
-            ),
-            WireNodeData.Response(),
-        )
-
         # Keep tree_msg up-to-date
         self.tree_msg.data_wirings = [
             wiring
@@ -1493,6 +1494,7 @@ class TreeManager:
                 and wiring.target.node_name not in names_to_remove
             )
         ]
+
         self.tree_msg.public_node_data = [
             data
             for data in self.tree_msg.public_node_data


### PR DESCRIPTION
@Oberacda  ready to review

#41 
Cause: 
- deleting the target node  in `TreeManager.remove_node()` before performing the unwiring
- as a result, `TreeManager.unwire_data()` failed because it  couldn't find a `target_node` and not remove the wiring.

Fix:
- perform `unwire_data()` before removing the node(s)