### PR TITLE
Fix: Data Wiring duplication check seems to not delete Date when moving/deleting Nodes

### DIFF
--- a/ros_bt_py/src/ros_bt_py/tree_manager.py
+++ b/ros_bt_py/src/ros_bt_py/tree_manager.py
@@ -1438,6 +1438,22 @@ class TreeManager:
             # If we're not removing the children, at least set their parent to None
             for child in self.nodes[request.node_name].children:
                 child.parent = None
+
+        # Unwire wirings that have removed nodes as source or target
+        self.unwire_data(
+            WireNodeData.Request(
+                wirings=[
+                    wiring
+                    for wiring in self.tree_msg.data_wirings
+                    if (
+                        wiring.source.node_name in names_to_remove
+                        or wiring.target.node_name in names_to_remove
+                    )
+                ]
+            ),
+            WireNodeData.Response(),
+        )
+
         # Remove nodes in the reverse order they were added to the
         # list, i.e. the "deepest" ones first. This ensures that the
         # parent we refer to in the error message still exists.
@@ -1469,21 +1485,6 @@ class TreeManager:
                 self.nodes[self.nodes[name].parent.name].remove_child(name)
             del self.nodes[name]
 
-        # Unwire wirings that have removed nodes as source or target
-        self.unwire_data(
-            WireNodeData.Request(
-                wirings=[
-                    wiring
-                    for wiring in self.tree_msg.data_wirings
-                    if (
-                        wiring.source.node_name in names_to_remove
-                        or wiring.target.node_name in names_to_remove
-                    )
-                ]
-            ),
-            WireNodeData.Response(),
-        )
-
         # Keep tree_msg up-to-date
         self.tree_msg.data_wirings = [
             wiring
@@ -1493,6 +1494,7 @@ class TreeManager:
                 and wiring.target.node_name not in names_to_remove
             )
         ]
+
         self.tree_msg.public_node_data = [
             data
             for data in self.tree_msg.public_node_data


### PR DESCRIPTION
@Oberacda Ready to review
Closes #41 
Cause:
- deleting the target node in TreeManager.remove_node() before performing the unwiring
- as a result, TreeManager.unwire_data() failed because it couldn't find a target_node and not remove the wiring.

Fix:
- perform unwire_data() before removing the node(s)