### PR TITLE
Minor fixes in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,19 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements](#suggesting-enhancements)
-- [Your First Code Contribution](#your-first-code-contribution)
-- [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-- [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
+- [Contributing to CONTRIBUTING.md](#contributing-to-contributingmd)
+  - [Table of Contents](#table-of-contents)
+  - [I Have a Question](#i-have-a-question)
+  - [I Want To Contribute](#i-want-to-contribute)
+    - [Legal Notice](#legal-notice)
+    - [Reporting Bugs](#reporting-bugs)
+      - [Before Submitting a Bug Report](#before-submitting-a-bug-report)
+      - [How Do I Submit a Good Bug Report?](#how-do-i-submit-a-good-bug-report)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+      - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
+      - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
+  - [Styleguides](#styleguides)
+  - [Attribution](#attribution)
 
 
 ## I Have a Question

--- a/ros_bt_py/CONTRIBUTING.md
+++ b/ros_bt_py/CONTRIBUTING.md
@@ -13,15 +13,19 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements](#suggesting-enhancements)
-- [Your First Code Contribution](#your-first-code-contribution)
-- [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-- [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
+- [Contributing to CONTRIBUTING.md](#contributing-to-contributingmd)
+  - [Table of Contents](#table-of-contents)
+  - [I Have a Question](#i-have-a-question)
+  - [I Want To Contribute](#i-want-to-contribute)
+    - [Legal Notice](#legal-notice)
+    - [Reporting Bugs](#reporting-bugs)
+      - [Before Submitting a Bug Report](#before-submitting-a-bug-report)
+      - [How Do I Submit a Good Bug Report?](#how-do-i-submit-a-good-bug-report)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+      - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
+      - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
+  - [Styleguides](#styleguides)
+  - [Attribution](#attribution)
 
 
 ## I Have a Question

--- a/ros_bt_py/doc/source/creating_node_classes.rst
+++ b/ros_bt_py/doc/source/creating_node_classes.rst
@@ -28,11 +28,11 @@ You really also should do step 4:
 
 Let's start with the skeleton of a new node class::
 
-  import rospy
+  import rclpy
 
   # Import the ROS message class under a different name
   # to avoid confusion. We need it for the node state names.
-  from ros_bt_py_msgs.msg import Node as NodeMsg
+  from ros_bt_py_interfaces.msg import Node as NodeMsg
 
   # We need these to define a Node.
   from ros_bt_py.node import Node, define_bt_node
@@ -128,11 +128,11 @@ list of our node's children.
 With all of the :code:`_do_` methods implemented the complete code
 looks like this::
 
-  import rospy
+  import rclpy
 
   # Import the ROS message class under a different name
   # to avoid confusion. We need it for the node state names.
-  from ros_bt_py_msgs.msg import Node as NodeMsg
+  from ros_bt_py_interfaces.msg import Node as NodeMsg
 
   # We need these to define a Node.
   from ros_bt_py.node import Node, define_bt_node

--- a/ros_bt_py_interfaces/CONTRIBUTING.md
+++ b/ros_bt_py_interfaces/CONTRIBUTING.md
@@ -13,15 +13,19 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements](#suggesting-enhancements)
-- [Your First Code Contribution](#your-first-code-contribution)
-- [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-- [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
+- [Contributing to CONTRIBUTING.md](#contributing-to-contributingmd)
+  - [Table of Contents](#table-of-contents)
+  - [I Have a Question](#i-have-a-question)
+  - [I Want To Contribute](#i-want-to-contribute)
+    - [Legal Notice](#legal-notice)
+    - [Reporting Bugs](#reporting-bugs)
+      - [Before Submitting a Bug Report](#before-submitting-a-bug-report)
+      - [How Do I Submit a Good Bug Report?](#how-do-i-submit-a-good-bug-report)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+      - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
+      - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
+  - [Styleguides](#styleguides)
+  - [Attribution](#attribution)
 
 
 ## I Have a Question

--- a/ros_bt_py_web_gui/CONTRIBUTING.md
+++ b/ros_bt_py_web_gui/CONTRIBUTING.md
@@ -13,15 +13,19 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [I Have a Question](#i-have-a-question)
-- [I Want To Contribute](#i-want-to-contribute)
-- [Reporting Bugs](#reporting-bugs)
-- [Suggesting Enhancements](#suggesting-enhancements)
-- [Your First Code Contribution](#your-first-code-contribution)
-- [Improving The Documentation](#improving-the-documentation)
-- [Styleguides](#styleguides)
-- [Commit Messages](#commit-messages)
-- [Join The Project Team](#join-the-project-team)
+- [Contributing to CONTRIBUTING.md](#contributing-to-contributingmd)
+  - [Table of Contents](#table-of-contents)
+  - [I Have a Question](#i-have-a-question)
+  - [I Want To Contribute](#i-want-to-contribute)
+    - [Legal Notice](#legal-notice)
+    - [Reporting Bugs](#reporting-bugs)
+      - [Before Submitting a Bug Report](#before-submitting-a-bug-report)
+      - [How Do I Submit a Good Bug Report?](#how-do-i-submit-a-good-bug-report)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+      - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
+      - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
+  - [Styleguides](#styleguides)
+  - [Attribution](#attribution)
 
 
 ## I Have a Question


### PR DESCRIPTION
- Outdated Table of Contents: 
  - The ToC in all CONTRIBUTING.md files was outdated with some dead links and some missing entries
  → Updated table of contents
- Incorrect Imports in Documentation
  - Some imports in the documentation "Creating Node Classes" were incorrect. 
  - Despite not being used: `import rospy` seems to be a leftover from the ROS1 package 
  → replaced with `import rclpy`
  - `from ros_bt_py_msgs.msg import Node as NodeMsg` is not the correct import 
  → replaced with `from ros_bt_py_interfaces.msg import Node as NodeMsg` (on another documentation site ("Testing Node Classes") the correct import is already used