### PR TITLE
Add Config Tests

### DIFF
--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -199,9 +199,9 @@ class TestNodeConfig:
 
         expected_repr = (
             f"NodeConfig(inputs={example_inputs}, outputs={example_outputs}, "
+            f"options={example_options}, max_children={example_max_children}, "
+            f"optional_options={example_optional_options}, version={example_version})"
         )
-        f"options={example_options}, max_children={example_max_children}, "
-        f"optional_options={example_optional_options}, version={example_version})"
         assert repr(node_config) == expected_repr
 
     @staticmethod

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import pytest
-from ros_bt_py.node_config import OptionRef
+from ros_bt_py.node_config import OptionRef, NodeConfig
 
 
 @pytest.mark.parametrize("option_key", ["Test", 1, 1.0, True])
@@ -76,3 +76,85 @@ class TestOptionRefEqs:
     )
     def test_ne(same, other, result):
         assert (same != other) == result
+
+
+@pytest.fixture
+def example_inputs():
+    return {"input1": int, "input2": OptionRef(1)}
+
+
+@pytest.fixture
+def example_outputs():
+    return {"output1": float, "output2": OptionRef("Test")}
+
+
+@pytest.fixture
+def example_options():
+    return {"option1": str, "options2": bool}
+
+
+@pytest.fixture
+def example_optional_options():
+    return {"optional1": str, "optional2": int}
+
+
+@pytest.fixture
+def example_max_children():
+    return 3
+
+
+@pytest.fixture
+def example_version():
+    return "1.0"
+
+
+@pytest.fixture
+def example_tags():
+    return ["tag1", "tag2"]
+
+
+class TestNodeConfig:
+    def test_init_required(
+        example_inputs, example_outputs, example_options, example_max_children
+    ):
+        node_config = NodeConfig(
+            options=example_options,
+            inputs=example_inputs,
+            outputs=example_outputs,
+            max_children=example_max_children,
+        )
+        assert node_config.inputs == example_inputs
+        assert node_config.outputs == example_outputs
+        assert node_config.options == example_options
+        assert node_config.max_children == example_max_children
+        assert node_config.optional_options == []
+        assert node_config.tags == []
+        assert node_config.version == ""
+
+    def test_init_optional(
+        example_inputs,
+        example_outputs,
+        example_options,
+        example_optional_options,
+        example_max_children,
+        example_version,
+        example_tags,
+    ):
+
+        node_config = NodeConfig(
+            options=example_options,
+            inputs=example_inputs,
+            outputs=example_outputs,
+            max_children=example_max_children,
+            optional_options=example_optional_options,
+            version=example_version,
+            tags=example_tags,
+        )
+
+        assert node_config.inputs == example_inputs
+        assert node_config.outputs == example_outputs
+        assert node_config.options == example_options
+        assert node_config.max_children == example_max_children
+        assert node_config.optional_options == example_optional_options
+        assert node_config.tags == example_tags
+        assert node_config.version == example_version

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -90,12 +90,12 @@ def example_outputs():
 
 @pytest.fixture
 def example_options():
-    return {"option1": str, "options2": bool}
+    return {"option1": str, "option2": bool}
 
 
 @pytest.fixture
 def example_optional_options():
-    return {"optional1": str, "optional2": int}
+    return ["optional1", "optional2"],
 
 
 @pytest.fixture
@@ -199,16 +199,16 @@ class TestNodeConfig:
         test_0 = NodeConfig(
             inputs={"input1": int, "input2": OptionRef(1)},
             outputs={"output1": float, "output2": OptionRef("Test")},
-            options={"option1": str, "options2": bool},
+            options={"option1": str, "option2": bool},
             max_children=3,
             optional_options={"optional1": str, "optional2": int},
             version="1.0",
         )
 
         test_1 = NodeConfig(
-            options={"option1": str, "options2": bool},
             inputs={"input1": int, "input2": OptionRef(1)},
             outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
             max_children=4,
             optional_options={"optional1": str, "optional2": int},
             version="1.0",
@@ -231,16 +231,16 @@ class TestNodeConfig:
         test_0 = NodeConfig(
             inputs={"input1": int, "input2": OptionRef(1)},
             outputs={"output1": float, "output2": OptionRef("Test")},
-            options={"option1": str, "options2": bool},
+            options={"option1": str, "option2": bool},
             max_children=3,
             optional_options={"optional1": str, "optional2": int},
             version="1.0",
         )
 
         test_1 = NodeConfig(
-            options={"option1": str, "options2": bool},
             inputs={"input1": int, "input2": OptionRef(1)},
             outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
             max_children=4,
             optional_options={"optional1": str, "optional2": int},
             version="1.0",

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -116,10 +116,12 @@ def example_tags():
 @pytest.fixture
 def example_config_0():
     return NodeConfig(
-        options={"option1": str, "options2": bool},
         inputs={"input1": int, "input2": OptionRef(1)},
         outputs={"output1": float, "output2": OptionRef("Test")},
+        options={"option1": str, "options2": bool},
         max_children=3,
+        optional_options={"optional1": str, "optional2": int},
+        version="1.0",
     )
 
 
@@ -129,6 +131,8 @@ def example_config_1():
         inputs={"input1": int, "input2": OptionRef(1)},
         outputs={"output1": float, "output2": OptionRef("Test")},
         max_children=4,
+        optional_options={"optional1": str, "optional2": int},
+        version="1.0",
     )
 
 

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -113,29 +113,6 @@ def example_tags():
     return ["tag1", "tag2"]
 
 
-@pytest.fixture
-def example_config_0():
-    return NodeConfig(
-        inputs={"input1": int, "input2": OptionRef(1)},
-        outputs={"output1": float, "output2": OptionRef("Test")},
-        options={"option1": str, "options2": bool},
-        max_children=3,
-        optional_options={"optional1": str, "optional2": int},
-        version="1.0",
-    )
-
-
-def example_config_1():
-    return NodeConfig(
-        options={"option1": str, "options2": bool},
-        inputs={"input1": int, "input2": OptionRef(1)},
-        outputs={"output1": float, "output2": OptionRef("Test")},
-        max_children=4,
-        optional_options={"optional1": str, "optional2": int},
-        version="1.0",
-    )
-
-
 class TestNodeConfig:
     def test_init_required(
         example_inputs, example_outputs, example_options, example_max_children
@@ -212,24 +189,62 @@ class TestNodeConfig:
     @pytest.mark.parametrize(
         "same, other, result",
         [
-            (example_config_0, example_config_0, True),
-            (example_config_0, example_config_1, False),
-            (example_config_1, example_config_0, False),
-            (example_config_1, example_config_1, True),
+            (0, 0, True),
+            (0, 1, False),
+            (1, 0, False),
+            (1, 1, True),
         ],
     )
     def test_eq(same, other, result):
-        assert (same == other) == result
+        test_0 = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "options2": bool},
+            max_children=3,
+            optional_options={"optional1": str, "optional2": int},
+            version="1.0",
+        )
+
+        test_1 = NodeConfig(
+            options={"option1": str, "options2": bool},
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            max_children=4,
+            optional_options={"optional1": str, "optional2": int},
+            version="1.0",
+        )
+        node_config_0 = test_0 if same == 0 else test_1
+        node_config_1 = test_0 if other == 0 else test_1
+        assert (node_config_0 == node_config_1) == result
 
     @staticmethod
     @pytest.mark.parametrize(
         "same, other, result",
         [
-            (example_config_0, example_config_0, False),
-            (example_config_0, example_config_1, True),
-            (example_config_1, example_config_0, True),
-            (example_config_1, example_config_1, False),
+            (0, 0, False),
+            (0, 1, True),
+            (1, 0, True),
+            (1, 1, False),
         ],
     )
     def test_ne(same, other, result):
-        assert (same != other) == result
+        test_0 = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "options2": bool},
+            max_children=3,
+            optional_options={"optional1": str, "optional2": int},
+            version="1.0",
+        )
+
+        test_1 = NodeConfig(
+            options={"option1": str, "options2": bool},
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            max_children=4,
+            optional_options={"optional1": str, "optional2": int},
+            version="1.0",
+        )
+        node_config_0 = test_0 if same == 0 else test_1
+        node_config_1 = test_0 if other == 0 else test_1
+        assert (node_config_0 != node_config_1) == result

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -113,6 +113,25 @@ def example_tags():
     return ["tag1", "tag2"]
 
 
+@pytest.fixture
+def example_config_0():
+    return NodeConfig(
+        options={"option1": str, "options2": bool},
+        inputs={"input1": int, "input2": OptionRef(1)},
+        outputs={"output1": float, "output2": OptionRef("Test")},
+        max_children=3,
+    )
+
+
+def example_config_1():
+    return NodeConfig(
+        options={"option1": str, "options2": bool},
+        inputs={"input1": int, "input2": OptionRef(1)},
+        outputs={"output1": float, "output2": OptionRef("Test")},
+        max_children=4,
+    )
+
+
 class TestNodeConfig:
     def test_init_required(
         example_inputs, example_outputs, example_options, example_max_children
@@ -158,3 +177,55 @@ class TestNodeConfig:
         assert node_config.optional_options == example_optional_options
         assert node_config.tags == example_tags
         assert node_config.version == example_version
+
+    def test_repr(
+        example_inputs,
+        example_outputs,
+        example_options,
+        example_optional_options,
+        example_max_children,
+        example_version,
+        example_tags,
+    ):
+        node_config = NodeConfig(
+            options=example_options,
+            inputs=example_inputs,
+            outputs=example_outputs,
+            max_children=example_max_children,
+            optional_options=example_optional_options,
+            version=example_version,
+            tags=example_tags,
+        )
+
+        expected_repr = (
+            f"NodeConfig(inputs={example_inputs}, outputs={example_outputs}, "
+        )
+        f"options={example_options}, max_children={example_max_children}, "
+        f"optional_options={example_optional_options}, version={example_version})"
+        assert repr(node_config) == expected_repr
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "same, other, result",
+        [
+            (example_config_0, example_config_0, True),
+            (example_config_0, example_config_1, False),
+            (example_config_1, example_config_0, False),
+            (example_config_1, example_config_1, True),
+        ],
+    )
+    def test_eq(same, other, result):
+        assert (same == other) == result
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "same, other, result",
+        [
+            (example_config_0, example_config_0, False),
+            (example_config_0, example_config_1, True),
+            (example_config_1, example_config_0, True),
+            (example_config_1, example_config_1, False),
+        ],
+    )
+    def test_ne(same, other, result):
+        assert (same != other) == result

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -248,3 +248,178 @@ class TestNodeConfig:
         node_config_0 = test_0 if same == 0 else test_1
         node_config_1 = test_0 if other == 0 else test_1
         assert (node_config_0 != node_config_1) == result
+
+    def test_extend_success(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input3": int, "input4": OptionRef(1)},
+            outputs={"output3": float, "output4": OptionRef("Test")},
+            options={"option3": str, "option4": bool},
+            max_children=3,
+            optional_options=["optional3", "optional4"],
+            version="1.0",
+        )
+        base_config.extend(extension_config)
+        assert base_config.inputs == {
+            "input1": int,
+            "input2": OptionRef(1),
+            "input3": int,
+            "input4": OptionRef(1),
+        }
+        assert base_config.outputs == {
+            "output1": float,
+            "output2": OptionRef("Test"),
+            "output3": float,
+            "output4": OptionRef("Test"),
+        }
+        assert base_config.options == {
+            "option1": str,
+            "option2": bool,
+            "option3": str,
+            "option4": bool,
+        }
+        assert base_config.max_children == 3
+        assert base_config.optional_options == [
+            "optional1",
+            "optional2",
+            "optional3",
+            "optional4",
+        ]
+        assert base_config.version == "1.0"
+
+    def test_extend_diff_max_childs(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input3": int, "input4": OptionRef(1)},
+            outputs={"output3": float, "output4": OptionRef("Test")},
+            options={"option3": str, "option4": bool},
+            max_children=4,
+            optional_options=["optional3", "optional4"],
+            version="1.0",
+        )
+
+        with pytest.raises(ValueError) as error:
+            base_config.extend(extension_config)
+
+        expected_error_msg = (
+            f"Mismatch in max_children: {base_config.max_children} "
+            f"vs {extension_config.max_children}"
+        )
+        assert str(error.value) == expected_error_msg
+
+    def test_extend_duplicate_input(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input1": int, "input4": OptionRef(1)},
+            outputs={"output3": float, "output4": OptionRef("Test")},
+            options={"option3": str, "option4": bool},
+            max_children=3,
+            optional_options=["optional3", "optional4"],
+            version="1.0",
+        )
+
+        with pytest.raises(KeyError) as error:
+            base_config.extend(extension_config)
+
+        duplicate_inputs = ["input1"]
+        expected_error_msg = f"Duplicate keys: inputs: {str(duplicate_inputs)}"
+        assert expected_error_msg in str(error.value)
+
+    def test_extend_duplicate_output(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input3": int, "input4": OptionRef(1)},
+            outputs={"output1": float, "output4": OptionRef("Test")},
+            options={"option3": str, "option4": bool},
+            max_children=3,
+            optional_options=["optional3", "optional4"],
+            version="1.0",
+        )
+
+        with pytest.raises(KeyError) as error:
+            base_config.extend(extension_config)
+
+        duplicate_outputs = ["output1"]
+        expected_error_msg = f"Duplicate keys: outputs: {str(duplicate_outputs)}"
+        assert expected_error_msg in str(error.value)
+
+    def test_extend_duplicate_option(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input3": int, "input4": OptionRef(1)},
+            outputs={"output3": float, "output4": OptionRef("Test")},
+            options={"option1": str, "option4": bool},
+            max_children=3,
+            optional_options=["optional3", "optional4"],
+            version="1.0",
+        )
+
+        with pytest.raises(KeyError) as error:
+            base_config.extend(extension_config)
+
+        duplicate_options = ["option1"]
+        expected_error_msg = f"Duplicate keys: options: {str(duplicate_options)}"
+        assert expected_error_msg in str(error.value)
+
+    def test_extend_duplicate_optional_option(self):
+        base_config = NodeConfig(
+            inputs={"input1": int, "input2": OptionRef(1)},
+            outputs={"output1": float, "output2": OptionRef("Test")},
+            options={"option1": str, "option2": bool},
+            max_children=3,
+            optional_options=["optional1", "optional2"],
+            version="1.0",
+        )
+
+        extension_config = NodeConfig(
+            inputs={"input3": int, "input4": OptionRef(1)},
+            outputs={"output3": float, "output4": OptionRef("Test")},
+            options={"option3": str, "option4": bool},
+            max_children=3,
+            optional_options=["optional1", "optional4"],
+            version="1.0",
+        )
+
+        base_config.extend(extension_config)
+
+        assert base_config.optional_options == ["optional1", "optional2", "optional4"]

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -95,7 +95,7 @@ def example_options():
 
 @pytest.fixture
 def example_optional_options():
-    return ["optional1", "optional2"],
+    return (["optional1", "optional2"],)
 
 
 @pytest.fixture
@@ -201,7 +201,7 @@ class TestNodeConfig:
             outputs={"output1": float, "output2": OptionRef("Test")},
             options={"option1": str, "option2": bool},
             max_children=3,
-            optional_options={"optional1": str, "optional2": int},
+            optional_options=["optional1", "optional2"],
             version="1.0",
         )
 
@@ -210,7 +210,7 @@ class TestNodeConfig:
             outputs={"output1": float, "output2": OptionRef("Test")},
             options={"option1": str, "option2": bool},
             max_children=4,
-            optional_options={"optional1": str, "optional2": int},
+            optional_options=["optional1", "optional2"],
             version="1.0",
         )
         node_config_0 = test_0 if same == 0 else test_1
@@ -233,7 +233,7 @@ class TestNodeConfig:
             outputs={"output1": float, "output2": OptionRef("Test")},
             options={"option1": str, "option2": bool},
             max_children=3,
-            optional_options={"optional1": str, "optional2": int},
+            optional_options=["optional1", "optional2"],
             version="1.0",
         )
 
@@ -242,7 +242,7 @@ class TestNodeConfig:
             outputs={"output1": float, "output2": OptionRef("Test")},
             options={"option1": str, "option2": bool},
             max_children=4,
-            optional_options={"optional1": str, "optional2": int},
+            optional_options=["optional1", "optional2"],
             version="1.0",
         )
         node_config_0 = test_0 if same == 0 else test_1

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -35,19 +35,19 @@ class TestOptionRefInputs:
     @staticmethod
     def test_init(option_key):
         option_ref = OptionRef(option_key)
-        assert option_key == option_ref.option_key
+        assert option_ref.option_key == option_key
 
     @staticmethod
     def test_repr(option_key):
         option_ref = OptionRef(option_key)
         expected_repr = f"OptionRef(option_key={option_key!r})"
-        assert expected_repr == repr(option_ref)
+        assert repr(option_ref) == expected_repr
 
     @staticmethod
     def test_name(option_key):
         option_ref = OptionRef(option_key)
         expected_name = f"OptionRef(option_key={option_key!r})"
-        assert expected_name == option_ref.__name__()
+        assert option_ref.__name__() == expected_name
 
 
 class TestOptionRefEqs:
@@ -62,7 +62,7 @@ class TestOptionRefEqs:
         ],
     )
     def test_eq(same, other, result):
-        assert result == (same == other)
+        assert (same == other) == result
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -75,4 +75,4 @@ class TestOptionRefEqs:
         ],
     )
     def test_ne(same, other, result):
-        assert result == (same != other)
+        assert (same != other) == result

--- a/ros_bt_py/tests/test_node_config.py
+++ b/ros_bt_py/tests/test_node_config.py
@@ -1,0 +1,78 @@
+# Copyright 2023 FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the FZI Forschungszentrum Informatik nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+from ros_bt_py.node_config import OptionRef
+
+
+@pytest.mark.parametrize("option_key", ["Test", 1, 1.0, True])
+class TestOptionRefInputs:
+    @staticmethod
+    def test_init(option_key):
+        option_ref = OptionRef(option_key)
+        assert option_key == option_ref.option_key
+
+    @staticmethod
+    def test_repr(option_key):
+        option_ref = OptionRef(option_key)
+        expected_repr = f"OptionRef(option_key={option_key!r})"
+        assert expected_repr == repr(option_ref)
+
+    @staticmethod
+    def test_name(option_key):
+        option_ref = OptionRef(option_key)
+        expected_name = f"OptionRef(option_key={option_key!r})"
+        assert expected_name == option_ref.__name__()
+
+
+class TestOptionRefEqs:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "same, other, result",
+        [
+            (OptionRef("Same"), OptionRef("Same"), True),
+            (OptionRef("Same"), OptionRef("Other"), False),
+            (OptionRef("Other"), OptionRef("Same"), False),
+            (OptionRef("Other"), OptionRef("Other"), True),
+        ],
+    )
+    def test_eq(same, other, result):
+        assert result == (same == other)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "same, other, result",
+        [
+            (OptionRef("Same"), OptionRef("Same"), False),
+            (OptionRef("Same"), OptionRef("Other"), True),
+            (OptionRef("Other"), OptionRef("Same"), True),
+            (OptionRef("Other"), OptionRef("Other"), False),
+        ],
+    )
+    def test_ne(same, other, result):
+        assert result == (same != other)


### PR DESCRIPTION
During work on #37 I realized that I could not find tests for [the node_config](https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py/blob/main/ros_bt_py/src/ros_bt_py/node_config.py) file.

With this PR these tests are implemented as a prerequisite for #37 