### PR TITLE
Directly show inputs and outputs for Services/Topics/Actions

### DIFF
--- a/ros_bt_py/ros_bt_py/ros_nodes/action.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/action.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from threading import Lock
 from abc import ABC, abstractmethod
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 from enum import Enum
 
 import rclpy
@@ -42,6 +42,11 @@ from ros_bt_py_interfaces.msg import UtilityBounds
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
+from rclpy.client import Client
+from rclpy.node import Node
+from ros_bt_py.debug_manager import DebugManager
+from ros_bt_py.subtree_manager import SubtreeManager
+import inspect
 
 
 class ActionStates(Enum):
@@ -465,19 +470,18 @@ class ActionForSetType(ABC, Leaf):
         version="0.1.0",
         options={
             "action_type": type,
-            "goal_type": type,
-            "feedback_type": type,
-            "result_type": type,
+            "action_name": str,
+            "wait_for_action_server_seconds": float,
+            "timeout_seconds": float,
+            "fail_if_not_available": bool,
         },
-        inputs={"goal": OptionRef("goal_type")},
-        outputs={
-            "feedback": OptionRef("feedback_type"),
-            "result": OptionRef("result_type"),
-        },
+        inputs={},
+        outputs={},
         max_children=0,
+        optional_options=["fail_if_not_available"],
     )
 )
-class Action(ActionForSetType):
+class Action(Leaf):
     """
     Connect to a ROS action and sends the supplied goal.
 
@@ -491,8 +495,394 @@ class Action(ActionForSetType):
     re-sent on the next tick.
     """
 
+    _action_name: str
+    _goal_type: type
+    _feedback_type: type
+    _result_type: type
+    _ac: Optional[Client] = None
+
+    def __init__(
+        self,
+        options: Optional[Dict] = None,
+        debug_manager: Optional[DebugManager] = None,
+        subtree_manager: Optional[SubtreeManager] = None,
+        name: Optional[str] = None,
+        ros_node: Optional[Node] = None,
+        succeed_always: bool = False,
+        simulate_tick: bool = False,
+    ) -> None:
+        super().__init__(
+            options=options,
+            debug_manager=debug_manager,
+            subtree_manager=subtree_manager,
+            name=name,
+            ros_node=ros_node,
+            succeed_always=succeed_always,
+            simulate_tick=simulate_tick,
+        )
+
+        node_inputs = {}
+        node_outputs = {}
+
+        self._action_name = self.options["action_name"]
+        self._action_type = self.options["action_type"]
+
+        try:
+            self._goal_type = getattr(self.options["action_type"], "Goal")
+
+            if inspect.isclass(self._goal_type):
+                msg = self._goal_type()
+                for field in msg._fields_and_field_types:
+                    node_inputs[field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_inputs["in"] = self.options["action_type"]
+        except AttributeError:
+            node_inputs["in"] = self.options["action_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        try:
+            self._result_type = getattr(self.options["action_type"], "Result")
+            if inspect.isclass(self._result_type):
+                msg = self._result_type()
+                for field in msg._fields_and_field_types:
+                    node_outputs["result_" + field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_outputs["result_out"] = self.options["action_type"]
+        except AttributeError:
+            node_outputs["result_out"] = self.options["action_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        try:
+            self._feedback_type = getattr(self.options["action_type"], "Feedback")
+            if inspect.isclass(self._feedback_type):
+                msg = self._feedback_type()
+                for field in msg._fields_and_field_types:
+                    node_outputs["feedback_" + field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_outputs["feedback_out"] = self.options["action_type"]
+        except AttributeError:
+            node_outputs["feedback_out"] = self.options["action_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        self._register_node_data(source_map=node_inputs, target_map=self.inputs)
+        self._register_node_data(source_map=node_outputs, target_map=self.outputs)
+
+    def _do_setup(self):
+        if not self.has_ros_node:
+            error_msg = f"Node {self.name} does not have a reference to a ROS node!"
+            self.logerr(error_msg)
+            raise BehaviorTreeException(error_msg)
+        self._lock = Lock()
+        self._feedback = None
+        self._active_goal = None
+        self._result = None
+
+        self._internal_state = ActionStates.IDLE
+
+        self._new_goal_request_future = None
+        self._running_goal_handle = None
+        self._running_goal_future = None
+
+        self._cancel_goal_future = None
+
+        self._action_available = True
+        self._shutdown: bool = False
+
+        self._ac = ActionClient(
+            node=self.ros_node,
+            action_type=self._action_type,
+            action_name=self._action_name,
+            callback_group=ReentrantCallbackGroup(),
+        )
+
+        if not self._ac.wait_for_server(
+            timeout_sec=self.options["wait_for_action_server_seconds"]
+        ):
+            self._action_available = False
+            if (
+                "fail_if_not_available" not in self.options
+                or not self.options["fail_if_not_available"]
+            ):
+                raise BehaviorTreeException(
+                    f"Action server {self._action_name} not available after waiting "
+                    f"{self.options['wait_for_action_server_seconds']} seconds!"
+                )
+
+        self._last_goal_time: Optional[Time] = None
+
+        for k, v in self._result_type.get_fields_and_field_types().items():
+            self.outputs["result_" + k] = None
+
+        for k, v in self._feedback_type.get_fields_and_field_types().items():
+            self.outputs["feedback_" + k] = None
+
+        return NodeMsg.IDLE
+
+    def _feedback_cb(self, feedback) -> None:
+        self.logdebug(f"Received feedback message: {feedback}")
+        with self._lock:
+            self._feedback = feedback
+
+    def _do_tick_wait_for_action_complete(self) -> str:
+        if self._running_goal_handle is None or self._running_goal_future is None:
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.BROKEN
+
+        if self._running_goal_future.done():
+            self._result = self._running_goal_future.result()
+            if self._result is None:
+                self._running_goal_handle = None
+                self._running_goal_future = None
+                self._active_goal = None
+
+                self._internal_state = ActionStates.FINISHED
+
+                self.logdebug("Action result is none, action call must have failed!")
+                return NodeMsg.FAILED
+
+            # returns failed except the set.ouput() method returns True
+            new_state = NodeMsg.FAILED
+
+            res = self._result.result
+            for k, v in res.get_fields_and_field_types().items():
+                self.outputs["result_" + k] = getattr(res, k)
+
+            new_state = NodeMsg.SUCCEEDED
+            self._running_goal_handle = None
+            self._running_goal_future = None
+            self._result = None
+
+            self._internal_state = ActionStates.FINISHED
+
+            self.logdebug("Action succeeded, publishing result!")
+            return new_state
+
+        if self._running_goal_future.cancelled():
+            self._running_goal_handle = None
+            self._running_goal_future = None
+            self._active_goal = None
+
+            self._internal_state = ActionStates.FINISHED
+
+            self.logwarn("Action execution was cancelled by the remote server!")
+            return NodeMsg.FAILED
+        seconds_running = (
+            self._running_goal_start_time - self.ros_node.get_clock().now()
+        ).nanoseconds / 1e9
+
+        if seconds_running > self.options["timeout_seconds"]:
+            self.logwarn(f"Cancelling goal after {seconds_running:f} seconds!")
+
+            # This cancels the goal result future, this is not cancelling the goal.
+            self._running_goal_future.cancel()
+            self._running_goal_future = None
+
+            self._internal_state = ActionStates.REQUEST_GOAL_CANCELLATION
+            return NodeMsg.RUNNING
+
+        feed = self._feedback.feedback
+        for k, v in feed.get_fields_and_field_types().items():
+            self.outputs["feedback_" + k] = getattr(feed, k)
+
+        return NodeMsg.RUNNING
+
+    def _do_tick_cancel_running_goal(self) -> str:
+        if self._running_goal_handle is None:
+            self.logwarn(
+                "Goal cancellation was requested, but there is no handle to the running goal!"
+            )
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.BROKEN
+
+        self._cancel_goal_future = self._running_goal_handle.cancel_goal_async()
+        self._internal_state = ActionStates.WAITING_FOR_GOAL_CANCELLATION
+        return NodeMsg.SUCCEED
+
+    def _do_tick_wait_for_cancel_complete(self) -> str:
+        if self._cancel_goal_future is None:
+            self.logwarn(
+                "Waiting for goal cancellation to complete, but the future is none!"
+            )
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.BROKEN
+
+        if self._cancel_goal_future.done():
+            self.logdebug("Successfully cancelled goal exectution!")
+
+            self._cancel_goal_future = None
+            self._running_goal_handle = None
+            self._running_goal_future = None
+            self._active_goal = None
+
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.SUCCEED
+        if self._cancel_goal_future.cancelled():
+            self.logdebug("Goal cancellation was cancelled!")
+
+            self._cancel_goal_future = None
+            self._running_goal_handle = None
+            self._running_goal_future = None
+            self._active_goal = None
+
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.FAILURE
+        return NodeMsg.RUNNING
+
+    def _do_tick_send_new_goal(self) -> str:
+        """Tick to request the execution of a new goal on the action server."""
+        self._new_goal_request_future = self._ac.send_goal_async(
+            goal=self._input_goal, feedback_callback=self._feedback_cb
+        )
+
+        self._active_goal = self._input_goal
+        self._internal_state = ActionStates.WAITING_FOR_GOAL_ACCEPTANCE
+
+        return NodeMsg.SUCCEED
+
+    def _do_tick_wait_for_new_goal_complete(self) -> str:
+        """Tick to wait for the new goal to be accepted by the action server!."""
+        if self._new_goal_request_future is None:
+            self.logerr(
+                "Waiting for the goal to be accepted"
+                "on the action server, but the future is none!"
+            )
+            self._internal_state = ActionStates.IDLE
+            return NodeMsg.BROKEN
+
+        if self._new_goal_request_future.done():
+            self._running_goal_handle = self._new_goal_request_future.result()
+            self._new_goal_request_future = None
+
+            if self._running_goal_handle is None:
+                self.logwarn("Action goal was rejeced by the server!")
+                self._internal_state = ActionStates.FINISHED
+                return NodeMsg.FAILED
+
+            self._running_goal_start_time = self.ros_node.get_clock().now()
+            self._running_goal_future = self._running_goal_handle.get_result_async()
+
+            self._internal_state = ActionStates.WAITING_FOR_ACTION_COMPLETE
+            return NodeMsg.SUCCEED
+
+        if self._new_goal_request_future.cancelled():
+            self.logwarn("Request for a new goal was cancelled!")
+            self._new_goal_request_future = None
+            self._running_goal_handle = None
+            self._active_goal = None
+
+            self._internal_state = ActionStates.FINISHED
+            return NodeMsg.FAILED
+
+        return NodeMsg.RUNNING
+
+    def _do_tick(self):
+        if self.simulate_tick:
+            self.logdebug("Simulating tick. Action is not executing!")
+            if self.succeed_always:
+                return NodeMsg.SUCCEEDED
+
+            return NodeMsg.RUNNING
+
+        if not self._action_available:
+            if (
+                "fail_if_not_available" in self.options
+                and self.options["fail_if_not_available"]
+            ):
+                return NodeMsg.FAILED
+
+        self._input_goal = self._goal_type()
+        for k, v in self._input_goal.get_fields_and_field_types().items():
+            setattr(self._input_goal, k, self.inputs[k])
+
+        if self._internal_state == ActionStates.IDLE:
+            status = self._do_tick_send_new_goal()
+            if status not in [NodeMsg.SUCCEED]:
+                return status
+
+        if self._internal_state == ActionStates.WAITING_FOR_GOAL_ACCEPTANCE:
+            status = self._do_tick_wait_for_new_goal_complete()
+            if status not in [NodeMsg.SUCCEED]:
+                return status
+
+        if self._internal_state == ActionStates.WAITING_FOR_ACTION_COMPLETE:
+            if self._active_goal == self._input_goal:
+                return self._do_tick_wait_for_action_complete()
+            else:
+                # We have a new goal, we should cancel the running one!
+                self._internal_state = ActionStates.REQUEST_GOAL_CANCELLATION
+
+        if self._internal_state == ActionStates.REQUEST_GOAL_CANCELLATION:
+            status = self._do_tick_cancel_running_goal()
+            # Check if goal cancel request was succssful!
+            if status not in [NodeMsg.SUCCEED]:
+                return status
+
+        if self._internal_state == ActionStates.WAITING_FOR_GOAL_CANCELLATION:
+            return self._do_tick_wait_for_cancel_complete()
+
+        if self._internal_state == ActionStates.FINISHED:
+            return self._do_tick_finished()
+
+        return NodeMsg.BROKEN
+
+    def _do_tick_finished(self):
+        if self._active_goal == self._input_goal:
+            return self._state
+        else:
+            self._internal_state = ActionStates.IDLE
+            return NodeMsg.RUNNING
+
+    def _do_untick(self):
+        if self._internal_state == ActionStates.WAITING_FOR_ACTION_COMPLETE:
+            self._do_tick_cancel_running_goal()
+
+        self._last_goal_time = None
+        self._running_goal_future = None
+        self._running_goal_handle = None
+        self._cancel_goal_future = None
+        self._active_goal = None
+        self._feedback = None
+        self._internal_state = ActionStates.IDLE
+
+        return NodeMsg.IDLE
+
+    def _do_reset(self):
+        # same as untick...
+        self._do_untick()
+        # but also clear the outputs
+        for k, v in self._result_type.get_fields_and_field_types().items():
+            self.outputs["result_" + k] = None
+
+        for k, v in self._feedback_type.get_fields_and_field_types().items():
+            self.outputs["feedback_" + k] = None
+        return NodeMsg.IDLE
+
+    def _do_shutdown(self):
+        # nothing to do beyond what's done in reset
+        self._do_reset()
+        self._action_available = False
+
+    def _do_calculate_utility(self):
+        if not self.has_ros_node:
+            return UtilityBounds(can_execute=False)
+        if self._ac is None:
+            return UtilityBounds(can_execute=False)
+        if not self._ac.server_is_ready():
+            return UtilityBounds(can_execute=False)
+        return UtilityBounds(
+            can_execute=True,
+            has_lower_bound_success=True,
+            has_upper_bound_success=True,
+            has_lower_bound_failure=True,
+            has_upper_bound_failure=True,
+        )
+
+    """
     def set_action_attributes(self):
-        """Set all action attributes."""
+        Set all action attributes.
         self._action_type = self.options["action_type"]
         self._goal_type = self.options["goal_type"]
         self._feedback_type = self.options["feedback_type"]
@@ -506,3 +896,4 @@ class Action(ActionForSetType):
     def set_outputs(self):
         self.outputs["result"] = self._result.result
         return True
+    """

--- a/ros_bt_py/ros_bt_py/ros_nodes/service.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/service.py
@@ -44,21 +44,20 @@ from ros_bt_py.exceptions import BehaviorTreeException
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Dict, Tuple
 
+import inspect
+
 
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
         options={
             "service_type": type,
-            "request_type": type,
-            "response_type": type,
             "wait_for_response_seconds": float,
         },
         inputs={
-            "request": OptionRef("request_type"),
             "service_name": str,
         },
-        outputs={"response": OptionRef("response_type")},
+        outputs={},
         max_children=0,
     )
 )
@@ -79,11 +78,73 @@ class ServiceInput(Leaf):
     data.
     """
 
+    _request_type: type
+    _response_type: type
+    _service_client: Optional[Client] = None
+
+    def __init__(
+        self,
+        options: Optional[Dict] = None,
+        debug_manager: Optional[DebugManager] = None,
+        subtree_manager: Optional[SubtreeManager] = None,
+        name: Optional[str] = None,
+        ros_node: Optional[Node] = None,
+        succeed_always: bool = False,
+        simulate_tick: bool = False,
+    ) -> None:
+        super().__init__(
+            options=options,
+            debug_manager=debug_manager,
+            subtree_manager=subtree_manager,
+            name=name,
+            ros_node=ros_node,
+            succeed_always=succeed_always,
+            simulate_tick=simulate_tick,
+        )
+
+        node_inputs = {}
+        node_outputs = {}
+        try:
+            self._request_type = getattr(self.options["service_type"], "Request")
+            if inspect.isclass(self._request_type):
+                msg = self._request_type()
+                for field in msg._fields_and_field_types:
+                    node_inputs[field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_inputs["in"] = self.options["service_type"]
+        except AttributeError:
+            node_inputs["in"] = self.options["service_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        try:
+            self._response_type = getattr(self.options["service_type"], "Response")
+            if inspect.isclass(self._response_type):
+                msg = self._response_type()
+                for field in msg._fields_and_field_types:
+                    node_outputs[field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_outputs["out"] = self.options["service_type"]
+        except AttributeError:
+            node_outputs["out"] = self.options["service_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        self.node_config.extend(
+            NodeConfig(
+                options={}, inputs=node_inputs, outputs=node_outputs, max_children=0
+            )
+        )
+
+        self._register_node_data(source_map=node_inputs, target_map=self.inputs)
+        self._register_node_data(source_map=node_outputs, target_map=self.outputs)
+
     def _do_setup(self):
         self._service_client: Optional[Client] = None
         self._service_request_future: Optional[Future] = None
         self._reported_result: bool = False
-        self.outputs["response"] = None
+        for k, v in self._response_type.get_fields_and_field_types().items():
+            self.outputs[k] = None
 
         if not self.has_ros_node:
             raise BehaviorTreeException(
@@ -99,8 +160,8 @@ class ServiceInput(Leaf):
 
         self._last_service_call_time: Optional[Time] = None
         self._last_request = None
-        self._reported_result = False
-        self.outputs["response"] = None
+        for k, v in self._response_type.get_fields_and_field_types().items():
+            self.outputs[k] = None
 
         return NodeMsg.IDLE
 
@@ -128,12 +189,14 @@ class ServiceInput(Leaf):
                 return NodeMsg.FAILED
         # If theres' no service call in-flight, and we have already reported
         # the result (see below), start a new call and save the request
-        if (
-            self._service_request_future is None
-            or self._service_request_future.done()
-            or self._service_request_future.cancelled()
-        ):
-            self._last_request = self.inputs["request"]
+        if self._service_request_future is None:
+            self._last_request = self._request_type()
+            fields: dict[
+                str, type
+            ] = self._last_request.get_fields_and_field_types().items()
+            for k, v in fields:
+                setattr(self._last_request, k, self.inputs[k])
+
             self._reported_result = False
             self._last_service_call_time = self.ros_node.get_clock().now()
             self._service_request_future = self._service_client.call_async(
@@ -169,11 +232,12 @@ class ServiceInput(Leaf):
             new_state = NodeMsg.SUCCEEDED
             if self._service_request_future.done():
                 res = self._service_request_future.result()
-                self.outputs["response"] = res
+                fields = res.get_fields_and_field_types().items()
+                for k, v in fields:
+                    self.outputs[k] = getattr(res, k)
             if self._service_request_future.cancelled():
-                self.logerr("FAILED")
                 new_state = NodeMsg.FAILED
-
+            self._service_request_future = None
             self._reported_result = True
             return new_state
 
@@ -183,9 +247,11 @@ class ServiceInput(Leaf):
             and not self._service_request_future.done()
         ):
             self._service_request_future.cancel()
+        self._service_request_future = None
         return NodeMsg.IDLE
 
     def _do_shutdown(self):
+        self._service_request_future = None
         if self._service_client is not None:
             self.ros_node.destroy_client(self._service_client)
 
@@ -610,14 +676,20 @@ class ServiceForSetType(ABC, Leaf):
 
 @define_bt_node(
     NodeConfig(
-        version="0.9.0",
-        options={"service_type": type, "request_type": type, "response_type": type},
-        inputs={"request": OptionRef("request_type")},
-        outputs={"response": OptionRef("response_type")},
+        options={
+            "service_name": str,
+            "service_type": type,
+            "wait_for_service_seconds": float,
+            "wait_for_response_seconds": float,
+            "fail_if_not_available": bool,
+        },
+        inputs={},
+        outputs={},
         max_children=0,
+        optional_options=["fail_if_not_available"],
     )
 )
-class Service(ServiceForSetType):
+class Service(Leaf):
     """
     Call a ROS service with the provided Request data.
 
@@ -633,21 +705,204 @@ class Service(ServiceForSetType):
     data.
     """
 
-    def set_service_type(self):
-        self._service_type = self.options["service_type"]
+    _service_client: Optional[Client] = None
+    _service_request_future: Optional[Future] = None
+    _last_service_call_time: Optional[Time] = None
+    _last_request: Optional[Any] = None
+    _reported_result: bool = False
+    _service_name: str
+    _request_type: type
+    _response_type: type
 
-    # Set all outputs to none (define output key while overwriting)
-    def set_output_none(self):
-        self.outputs["response"] = None
+    def __init__(
+        self,
+        options: Optional[Dict] = None,
+        debug_manager: Optional[DebugManager] = None,
+        subtree_manager: Optional[SubtreeManager] = None,
+        name: Optional[str] = None,
+        ros_node: Optional[Node] = None,
+        succeed_always: bool = False,
+        simulate_tick: bool = False,
+    ) -> None:
+        super().__init__(
+            options=options,
+            debug_manager=debug_manager,
+            subtree_manager=subtree_manager,
+            name=name,
+            ros_node=ros_node,
+            succeed_always=succeed_always,
+            simulate_tick=simulate_tick,
+        )
 
-    # Sets the service request message, sent to the service.
-    def set_request(self):
-        self._last_request = self.inputs["request"]
+        node_inputs = {}
+        node_outputs = {}
+        try:
+            self._request_type = getattr(self.options["service_type"], "Request")
+            if inspect.isclass(self._request_type):
+                msg = self._request_type()
+                for field in msg._fields_and_field_types:
+                    node_inputs[field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_inputs["in"] = self.options["service_type"]
+        except AttributeError:
+            node_inputs["in"] = self.options["service_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
 
-    # Sets the output (in relation to the response) (define output key while overwriting)
-    # it should return True, if the node state should be SUCCEEDED after receiving the message and
-    # False. if it should be in the FAILED state
-    def set_outputs(self):
-        self.outputs["response"] = self._service_request_future.result()
-        print(f"{self.outputs['response']}")
-        return self.outputs["response"]
+        try:
+            self._response_type = getattr(self.options["service_type"], "Response")
+            if inspect.isclass(self._response_type):
+                msg = self._response_type()
+                for field in msg._fields_and_field_types:
+                    node_outputs[field] = type(getattr(msg, field))
+                self.passthrough = False
+            else:
+                node_outputs["out"] = self.options["service_type"]
+        except AttributeError:
+            node_outputs["out"] = self.options["service_type"]
+            self.logwarn(f"Non message type passed to: {self.name}")
+
+        self.node_config.extend(
+            NodeConfig(
+                options={}, inputs=node_inputs, outputs=node_outputs, max_children=0
+            )
+        )
+
+        self._register_node_data(source_map=node_inputs, target_map=self.inputs)
+        self._register_node_data(source_map=node_outputs, target_map=self.outputs)
+
+    def _do_setup(self):
+        self._service_client: Optional[Client] = None
+        self._service_request_future: Optional[Future] = None
+        self._reported_result: bool = False
+        for k, v in self._response_type.get_fields_and_field_types().items():
+            self.outputs[k] = None
+
+        if not self.has_ros_node:
+            raise BehaviorTreeException(
+                "ROS service node does not have ROS node reference!"
+            )
+
+        return NodeMsg.IDLE
+
+    def _do_reset(self):
+        if self._service_client is not None:
+            self.ros_node.destroy_client(self._service_client)
+            self._service_client = None
+
+        self._last_service_call_time: Optional[Time] = None
+        self._last_request = None
+        self._reported_result = False
+        for k, v in self._response_type.get_fields_and_field_types().items():
+            self.outputs[k] = None
+
+        return NodeMsg.IDLE
+
+    def _do_tick(self):
+        if self.simulate_tick:
+            self.logdebug(f"Simulating tick. {self.name} is not executing!")
+            if self.succeed_always:
+                return NodeMsg.SUCCEEDED
+
+            return NodeMsg.RUNNING
+
+        if self._service_client is None:
+            if self.has_ros_node:
+                self._service_client = self.ros_node.create_client(
+                    self.options["service_type"],
+                    self.options["service_name"],
+                    callback_group=ReentrantCallbackGroup(),
+                )
+            else:
+                self.logerr(f"No ROS node available for node: {self.name}!")
+                return NodeMsg.FAILED
+        # If theres' no service call in-flight, and we have already reported
+        # the result (see below), start a new call and save the request
+        if self._service_request_future is None:
+            self._last_request = self._request_type()
+            fields: dict[
+                str, type
+            ] = self._last_request.get_fields_and_field_types().items()
+            for k, v in fields:
+                setattr(self._last_request, k, self.inputs[k])
+
+            self._last_service_call_time = self.ros_node.get_clock().now()
+            self._service_request_future = self._service_client.call_async(
+                self._last_request
+            )
+
+        if self._service_request_future is not None and not (
+            self._service_request_future.done()
+            or self._service_request_future.cancelled()
+        ):
+            # If the call takes longer than the specified timeout, abort the
+            # call and return FAILED
+            if self._last_service_call_time is None:
+                self.logwarn(
+                    "No previous timeout start timestamp set! Timeout starts now"
+                )
+                self._last_service_call_time = self.ros_node.get_clock().now()
+
+            seconds_since_call: Duration = (
+                self.ros_node.get_clock().now() - self._last_service_call_time
+            ).nanoseconds / 1e9
+
+            if seconds_since_call > self.options["wait_for_response_seconds"]:
+                self.logerr(
+                    f"Service call to {self.options['service_name']} with request "
+                    f"{self._last_request} timed out after {seconds_since_call} seconds"
+                )
+                self._service_request_future.cancel()
+                return NodeMsg.FAILED
+
+            return NodeMsg.RUNNING
+        else:
+            new_state = NodeMsg.SUCCEEDED
+            if self._service_request_future.done():
+                res = self._service_request_future.result()
+                fields = res.get_fields_and_field_types().items()
+                for k, v in fields:
+                    self.outputs[k] = getattr(res, k)
+
+            if self._service_request_future.cancelled():
+                new_state = NodeMsg.FAILED
+
+            self._service_request_future = None
+            self._reported_result = True
+            return new_state
+
+    def _do_untick(self):
+        if (
+            self._service_request_future is not None
+            and not self._service_request_future.done()
+        ):
+            self._service_request_future.cancel()
+        return NodeMsg.IDLE
+
+    def _do_shutdown(self):
+        if self._service_client is not None:
+            self.ros_node.destroy_client(self._service_client)
+
+    def _do_calculate_utility(self):
+        if not self.has_ros_node or self._service_client is None:
+            self.loginfo(
+                f"Unable to check for service {self.options['service_name']}, "
+                "ros node available!"
+            )
+            return UtilityBounds()
+
+        if self._service_client.service_is_ready():
+            self.loginfo(
+                f"Found service {self.options['service_name']} with correct type, returning "
+                "filled out UtilityBounds"
+            )
+            return UtilityBounds(
+                can_execute=True,
+                has_lower_bound_success=True,
+                has_upper_bound_success=True,
+                has_lower_bound_failure=True,
+                has_upper_bound_failure=True,
+            )
+
+        self.loginfo(f"Service {self.options['service_name']} is unavailable")
+        return UtilityBounds(can_execute=False)

--- a/ros_bt_py/tests/ros_nodes/test_service.py
+++ b/ros_bt_py/tests/ros_nodes/test_service.py
@@ -54,8 +54,6 @@ def test_node_success(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -68,7 +66,7 @@ def test_node_success(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service.state == NodeMsg.IDLE
     request = SetBool.Request()
     request.data = False
-    unavailable_service.inputs["request"] = request
+    unavailable_service.inputs["data"] = request.data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
     client_mock.call_async.assert_called_with(request)
@@ -77,7 +75,7 @@ def test_node_success(ros_mock, client_mock, future_mock, clock_mock):
 
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.SUCCEEDED
-    assert unavailable_service.outputs["response"].success
+    assert unavailable_service.outputs["success"]
 
     unavailable_service.shutdown()
     assert unavailable_service.state == NodeMsg.SHUTDOWN
@@ -103,8 +101,6 @@ def test_node_failure(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -115,7 +111,7 @@ def test_node_failure(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.FAILED
 
@@ -139,8 +135,6 @@ def test_node_timeout(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -151,7 +145,7 @@ def test_node_timeout(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -185,8 +179,6 @@ def test_node_reset_shutdown(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -197,7 +189,7 @@ def test_node_reset_shutdown(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -205,7 +197,7 @@ def test_node_reset_shutdown(ros_mock, client_mock, future_mock, clock_mock):
 
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.SUCCEEDED
-    assert unavailable_service.outputs["response"].success
+    assert unavailable_service.outputs["success"]
 
     unavailable_service.reset()
     assert unavailable_service.state == NodeMsg.IDLE
@@ -240,8 +232,6 @@ def test_node_reset(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -252,7 +242,7 @@ def test_node_reset(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -260,7 +250,7 @@ def test_node_reset(ros_mock, client_mock, future_mock, clock_mock):
 
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.SUCCEEDED
-    assert unavailable_service.outputs["response"].success
+    assert unavailable_service.outputs["success"]
 
     unavailable_service.reset()
 
@@ -278,7 +268,7 @@ def test_node_reset(ros_mock, client_mock, future_mock, clock_mock):
     ]
 
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -286,7 +276,7 @@ def test_node_reset(ros_mock, client_mock, future_mock, clock_mock):
 
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.SUCCEEDED
-    assert not unavailable_service.outputs["response"].success
+    assert not unavailable_service.outputs["success"]
 
 
 def test_node_no_ros():
@@ -295,8 +285,6 @@ def test_node_no_ros():
             options={
                 "service_name": "this_service_does_not_exist",
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
                 "wait_for_service_seconds": 5.0,
                 "fail_if_not_available": True,
@@ -333,8 +321,6 @@ def test_node_untick(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -345,7 +331,7 @@ def test_node_untick(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -380,8 +366,6 @@ def test_node_utility_no_ros(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -395,8 +379,6 @@ def test_node_utility_no_ros(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -432,8 +414,6 @@ def test_node_utility(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -443,7 +423,7 @@ def test_node_utility(ros_mock, client_mock, future_mock, clock_mock):
     assert unavailable_service is not None
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
     unavailable_service.tick()
     assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -487,8 +467,6 @@ def test_node_simulate_tick(ros_mock, client_mock, future_mock, clock_mock):
         options={
             "service_name": "this_service_does_not_exist",
             "service_type": SetBool,
-            "request_type": SetBool.Request,
-            "response_type": SetBool.Response,
             "wait_for_response_seconds": 5.0,
             "wait_for_service_seconds": 5.0,
             "fail_if_not_available": True,
@@ -499,7 +477,7 @@ def test_node_simulate_tick(ros_mock, client_mock, future_mock, clock_mock):
     unavailable_service.setup()
     assert unavailable_service.state == NodeMsg.IDLE
 
-    unavailable_service.inputs["request"] = SetBool.Request()
+    unavailable_service.inputs["data"] = SetBool.Request().data
 
     unavailable_service.simulate_tick = True
     unavailable_service.tick()

--- a/ros_bt_py/tests/ros_nodes/test_service_input.py
+++ b/ros_bt_py/tests/ros_nodes/test_service_input.py
@@ -54,8 +54,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -65,7 +63,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -73,7 +71,7 @@ class TestServiceInput:
 
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.SUCCEEDED
-        assert unavailable_service.outputs["response"].success
+        assert unavailable_service.outputs["success"]
 
         unavailable_service.shutdown()
         assert unavailable_service.state == NodeMsg.SHUTDOWN
@@ -97,8 +95,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -108,7 +104,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.FAILED
 
@@ -130,8 +126,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -141,7 +135,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -173,8 +167,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -184,7 +176,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -192,7 +184,7 @@ class TestServiceInput:
 
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.SUCCEEDED
-        assert unavailable_service.outputs["response"].success
+        assert unavailable_service.outputs["success"]
 
         unavailable_service.reset()
         assert unavailable_service.state == NodeMsg.IDLE
@@ -228,8 +220,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -239,7 +229,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -247,7 +237,7 @@ class TestServiceInput:
 
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.SUCCEEDED
-        assert unavailable_service.outputs["response"].success
+        assert unavailable_service.outputs["success"]
 
         unavailable_service.reset()
 
@@ -266,7 +256,7 @@ class TestServiceInput:
 
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -274,15 +264,13 @@ class TestServiceInput:
 
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.SUCCEEDED
-        assert not unavailable_service.outputs["response"].success
+        assert not unavailable_service.outputs["success"]
 
     def test_node_no_ros(self):
         with pytest.raises(BehaviorTreeException):
             unavailable_service = ServiceInput(
                 options={
                     "service_type": SetBool,
-                    "request_type": SetBool.Request,
-                    "response_type": SetBool.Response,
                     "wait_for_response_seconds": 5.0,
                 },
                 ros_node=None,
@@ -315,8 +303,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -327,7 +313,7 @@ class TestServiceInput:
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.ros_node = None
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.FAILED
 
@@ -355,8 +341,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -366,7 +350,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -399,8 +383,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -410,7 +392,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -442,8 +424,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=None,
@@ -454,8 +434,6 @@ class TestServiceInput:
         unavailable_service_2 = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -490,8 +468,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -500,7 +476,7 @@ class TestServiceInput:
         unavailable_service.setup()
         assert unavailable_service.state == NodeMsg.IDLE
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
         unavailable_service.tick()
         assert unavailable_service.state == NodeMsg.RUNNING
 
@@ -542,8 +518,6 @@ class TestServiceInput:
         unavailable_service = ServiceInput(
             options={
                 "service_type": SetBool,
-                "request_type": SetBool.Request,
-                "response_type": SetBool.Response,
                 "wait_for_response_seconds": 5.0,
             },
             ros_node=ros_mock,
@@ -553,7 +527,7 @@ class TestServiceInput:
         assert unavailable_service.state == NodeMsg.IDLE
 
         unavailable_service.inputs["service_name"] = "this_service_does_not_exist"
-        unavailable_service.inputs["request"] = SetBool.Request()
+        unavailable_service.inputs["data"] = SetBool.Request().data
 
         unavailable_service.simulate_tick = True
         unavailable_service.tick()


### PR DESCRIPTION
Services/Topics/Actions get a Request/Response or Message as input or output. This PR changes it so that the fields of the messages are shown directly on the node.