### PR TITLE
Update the get_message_fields Service

### DIFF
--- a/ros_bt_py/ros_bt_py/package_manager.py
+++ b/ros_bt_py/ros_bt_py/package_manager.py
@@ -255,9 +255,10 @@ class PackageManager(object):
                 )
             for field in message_class._fields_and_field_types:
                 response.field_names.append(field.strip())
-            response.fields = json_encode(
-                rosidl_runtime_py.message_to_ordereddict(message_class())
-            )
+            #response.fields = json_encode(
+            #    rosidl_runtime_py.message_to_ordereddict(message_class())
+            #)
+            response.fields = json_encode(message_class())
             response.success = True
         except Exception as e:
             response.success = False

--- a/ros_bt_py_interfaces/srv/GetMessageFields.srv
+++ b/ros_bt_py_interfaces/srv/GetMessageFields.srv
@@ -38,6 +38,6 @@ bool action
 uint8 type
 ---
 string fields
-string[] field_names
+string field_types
 bool success
 string error_message


### PR DESCRIPTION
Rewrite the service handler to produce a json-encoded dictionary of the editable fields instead of serializing the whole message object.

Also replace the field_names attribute of the GetMessageFields.Respose with field_types, which is filled with a dictionary providing recursive type information on the aforementioned fields.

**Note**: The recursive type information currently halts at list-valued fields (producing "sequence<...>") since there is no easy way to access field data of the sequence's elementary type.