### PR TITLE
Add Jazzy / Ubuntu 24.04 to Git issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -55,7 +55,7 @@ body:
   - type: dropdown
     id: ros2_version
     attributes:
-      label: "ROS2 Version"
+      label: "ROS 2 Version"
       description: What ROS 2 versions are you seeing the problem on?
       multiple: true
       options:

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -56,25 +56,26 @@ body:
     id: ros2_version
     attributes:
       label: "ROS2 Version"
-      description: What ROS2 versions are you seeing the problem on ?
+      description: What ROS 2 versions are you seeing the problem on?
       multiple: true
       options:
         - Rolling
-        - Humble
+        - Jazzy
         - Iron
-        - Foxy
+        - Humble
     validations:
       required: false
   - type: dropdown
     id: os
     attributes:
       label: "OS"
-      description: What is the impacted environment ?
+      description: What is the impacted environment?
       multiple: true
       options:
         - Windows
         - Ubuntu 20.04
         - Ubuntu 22.04
+        - Ubuntu 24.04
         - RHEL
         - Fedora
         - Mac


### PR DESCRIPTION
I was submitting a bug on ROS 2 Jazzy / Ubuntu 24.04 and noticed the issue template didn't include these options.