### PR TITLE
TypeWrapper for option type info and updated get_message_fields Service

### DIFF
--- a/ros_bt_py/ros_bt_py/custom_types.py
+++ b/ros_bt_py/ros_bt_py/custom_types.py
@@ -30,7 +30,22 @@ from abc import ABC, abstractmethod
 import rosidl_runtime_py
 import rosidl_runtime_py.utilities
 
-# TODO Math types for operation and operand remain in `helpers.py`
+
+class HintedType(object):
+
+    def __init__(self, hints=None):
+        if hints is None:
+            self.hints = []
+        else:
+            self.hints = hints
+
+
+class FilePath(object):
+    def __init__(self, path=''):
+        self.path = path
+
+
+#TODO Math types for operation and operand remain in `helpers.py`
 # to not cause a breaking change. If those are ever updated,
 # they should be moved here.
 from .helpers import MathBinaryOperator, MathUnaryOperator

--- a/ros_bt_py/ros_bt_py/custom_types.py
+++ b/ros_bt_py/ros_bt_py/custom_types.py
@@ -39,7 +39,7 @@ class TypeWrapper(object):
     This allows to wrap any builtin type to supply additional information,
     like restrictions, suggestions, ...
     """
-    def __init__(self, actual_type, info=''):
+    def __init__(self, actual_type: type, info=''):
         self.actual_type = actual_type
         self.info = info
 

--- a/ros_bt_py/ros_bt_py/custom_types.py
+++ b/ros_bt_py/ros_bt_py/custom_types.py
@@ -49,9 +49,9 @@ class FilePath(object):
         self.path = path
 
 
-#TODO Math types for operation and operand remain in `helpers.py`
-# to not cause a breaking change. If those are ever updated,
-# they should be moved here.
+#NOTE Math types for operation and operand remain in `helpers.py`
+# to not cause a breaking change. If there ever is a breaking change for those,
+# the new version should be moved here.
 from .helpers import MathBinaryOperator, MathUnaryOperator
 from .helpers import MathOperandType, MathUnaryOperandType
 
@@ -75,7 +75,7 @@ class RosType(ABC):
 
 
 class RosTopicType(RosType):
-    def __init__(self, type_str="std_msgs/msg/Empty"):
+    def __init__(self, type_str="example_interfaces/msg/Empty"):
         super().__init__(type_str)
 
     def get_type_obj(self):
@@ -83,7 +83,7 @@ class RosTopicType(RosType):
 
 
 class RosServiceType(RosType):
-    def __init__(self, type_str="std_srvs/srv/Trigger"):
+    def __init__(self, type_str="example_interfaces/srv/Trigger"):
         super().__init__(type_str)
 
     def get_type_obj(self):

--- a/ros_bt_py/ros_bt_py/custom_types.py
+++ b/ros_bt_py/ros_bt_py/custom_types.py
@@ -31,13 +31,17 @@ import rosidl_runtime_py
 import rosidl_runtime_py.utilities
 
 
-class HintedType(object):
-
-    def __init__(self, hints=None):
-        if hints is None:
-            self.hints = []
-        else:
-            self.hints = hints
+# NOTE These constants serve as docs for supported wrappings and to avoid typos
+TYPE_BUILTIN = 'builtin'
+DICT_ROS = 'ros'
+class TypeWrapper(object):
+    """
+    This allows to wrap any builtin type to supply additional information,
+    like restrictions, suggestions, ...
+    """
+    def __init__(self, actual_type, info=''):
+        self.actual_type = actual_type
+        self.info = info
 
 
 class FilePath(object):

--- a/ros_bt_py/ros_bt_py/helpers.py
+++ b/ros_bt_py/ros_bt_py/helpers.py
@@ -25,10 +25,14 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from typing import Any, Optional
 import jsonpickle
 import rclpy.logging
 import functools
+import re
 from collections import OrderedDict
+
+import rosidl_runtime_py.utilities
 
 from ros_bt_py_interfaces.msg import CapabilityInterface, Node, Tree
 from ros_bt_py.ros_helpers import EnumValue, LoggerLevel
@@ -122,6 +126,147 @@ def json_decode(data):
     """Wrap the call to jsonpickle.decode."""
     return jsonpickle.decode(data)
 
+
+def build_message_field_dicts(message_object: Any) -> tuple[dict, dict]:
+    """
+    Thin wrapper over `get_field_values_and_types` that allows passing a whole message object,
+    this will then iterate over all the message object's fields.
+
+    See the docs of `get_field_values_and_types` for details on what is returned.
+    """
+    default_message = message_object.__class__()
+    values_dict = {}
+    types_dict = {}
+    for field_name, field_type in message_object.get_fields_and_field_types().items():
+        values_dict[field_name], types_dict[field_name] = \
+            get_field_values_and_types(
+                field_type,
+                getattr(message_object, field_name),
+                getattr(default_message, field_name)
+            )
+    return values_dict, types_dict
+
+
+def get_field_values_and_types(field_type: str, field_value: Optional[Any], optional_default: Optional[Any]=None) -> tuple[Any, dict]:
+    """
+    Given a corresponding type string, current value and (optional) default value,
+    recursively identify the values and types of all fields.
+    The default_value is used to obtain custom defaults set at message definition,
+    if omitted, it will be recovered where possible, and fallbacks will be used where it's not.
+
+    The field values are returned as a simple recursive dictionary ending in values of buit-in types.
+    These are only valid if field_value is not None
+
+    The field types are given as a dictionary with three keys:
+        - 'own_type': the type of the field, may be one of the following:
+            - a built-in type
+            - a message class name
+            - the special keyword 'sequence' indicating an array field
+        - 'default_value': the default value of the built-in type, None otherwise
+        - 'nested_type': depending on the value of own_type, this is:
+            - None for built-in types
+            - a (recursive) dict with field names and types for message classes 
+            - a dict with a type specification (this) for 'sequence'
+        - 'max_length': only relevant for 'sequence' and 'string' types, 
+            equals -1 if it's unbounded and for all other types
+        - 'is_static': specifies if the max_length of 'sequence' is forced,
+            meaing the sequence has to be exactly this length. False for all other types
+    """
+    #Checks if the type matches a sequence definition and extracts the element-type and bounds
+    match_sequence = re.match(r"sequence<([\w\/<>]+)(?:, (\d+))?>", field_type)
+    #Checks if the type matches an array definition and extracts the element-type and bounds
+    match_array = re.match(r"([\w\/<>]*)\[(\d+)\]", field_type)
+    # Parse sequence and array types
+    if match_sequence or match_array:
+        # Recover defaults
+        default_value = optional_default
+        if optional_default is None:
+            default_value = []
+
+        nested_type_str: str
+        max_len_str: str
+        is_static = False
+        if match_sequence:
+            nested_type_str, max_len_str = match_sequence.groups()
+        if match_array:
+            nested_type_str, max_len_str = match_array.groups()
+            is_static = True
+        if max_len_str is None:
+            max_len = -1
+        else:
+            max_len = int(max_len_str)
+        _, nested_type = get_field_values_and_types(nested_type_str, None)
+        nested_values = []
+        if not field_value is None:
+            for val in field_value:
+                nval, _ = get_field_values_and_types(nested_type_str, val)
+                nested_values.append(nval)
+        return nested_values, {
+            'own_type': field_type,
+            'default_value': None, 
+            'nested_type': nested_type,
+            'max_length': max_len,
+            'is_static': is_static,
+        }
+    
+    # Check if the type matches a message type
+    if field_type.find('/') != -1:
+        # Get default field values
+        default_value = optional_default
+        if optional_default is None:
+            default_value = rosidl_runtime_py.utilities.get_message(field_type)()
+
+        # Iterate fields for recursion
+        nested_value = {}
+        nested_type = {}
+        for fname, ftype in default_value.get_fields_and_field_types().items():
+            nested_value[fname], nested_type[fname] = get_field_values_and_types(
+                ftype, 
+                getattr(field_value, fname, None),
+                getattr(default_value, fname),
+            )
+        return nested_value, {
+            'own_type': field_type,
+            'default_value': None,
+            'nested_type': nested_type,
+            'max_length': -1,
+            'is_static': False,
+        }
+    
+    # Parse built-in types
+    fallback_default: Any = None
+    max_len = -1
+    if field_type.find('bool') != -1:
+        fallback_default = False
+    elif field_type.find('int') != -1 or \
+        field_type.find('long') != -1 or \
+        field_type.find('char') != -1:
+        fallback_default = 0
+    elif field_type.find('float') != -1 or \
+        field_type.find('double') != -1:
+        fallback_default = 0.0
+    elif field_type.find('octet') != -1:
+        fallback_default = b'\x00'
+    elif field_type.find('string') != -1:
+        fallback_default = ''
+        match_length = re.match(r"\w+<(\d+)>", field_type)
+        if match_length:
+            max_len = int( match_length[1] )
+    else:
+        rclpy.logging.get_logger("package_manager") \
+            .warn(f"Unidentified built-in type {field_type}")
+        
+    default_value = optional_default
+    if optional_default is None:
+        default_value = fallback_default
+
+    return field_value, {
+        'own_type': field_type,
+        'default_value': default_value,
+        'nested_type': None,
+        'max_length': max_len,
+        'is_static': False,
+    }
 
 
 class HashableCapabilityInterface:

--- a/ros_bt_py/ros_bt_py/node.py
+++ b/ros_bt_py/ros_bt_py/node.py
@@ -50,6 +50,7 @@ from ros_bt_py.exceptions import BehaviorTreeException, NodeStateError, NodeConf
 from ros_bt_py.node_data import NodeData, NodeDataMap
 from ros_bt_py.node_config import NodeConfig, OptionRef
 from ros_bt_py.helpers import get_default_value, json_decode
+from ros_bt_py.custom_types import HintedType
 
 
 def _check_node_data_match(
@@ -971,6 +972,14 @@ class Node(object):
           * If an OptionRef references an option value that does not hold a `type`
 
         """
+        # Replace any instances of HintedType with type to not mess with internal logic
+        # HintedType is only meant to display additional information.
+        for key, value in source_map.items():
+            if isinstance(value, HintedType):
+                source_map[key] = type
+            else:
+                source_map[key] = value
+
         # Find the values that are not OptionRefs first
         self._find_option_refs(
             source_map=source_map,

--- a/ros_bt_py/ros_bt_py/node.py
+++ b/ros_bt_py/ros_bt_py/node.py
@@ -50,7 +50,7 @@ from ros_bt_py.exceptions import BehaviorTreeException, NodeStateError, NodeConf
 from ros_bt_py.node_data import NodeData, NodeDataMap
 from ros_bt_py.node_config import NodeConfig, OptionRef
 from ros_bt_py.helpers import get_default_value, json_decode
-from ros_bt_py.custom_types import HintedType
+
 
 
 def _check_node_data_match(
@@ -972,13 +972,6 @@ class Node(object):
           * If an OptionRef references an option value that does not hold a `type`
 
         """
-        # Replace any instances of HintedType with type to not mess with internal logic
-        # HintedType is only meant to display additional information.
-        for key, value in source_map.items():
-            if isinstance(value, HintedType):
-                source_map[key] = type
-            else:
-                source_map[key] = value
 
         # Find the values that are not OptionRefs first
         self._find_option_refs(

--- a/ros_bt_py/ros_bt_py/node_data.py
+++ b/ros_bt_py/ros_bt_py/node_data.py
@@ -127,21 +127,21 @@ class NodeData(object):
 
         if not isinstance(new_value, real_data_type) and new_value is not None:
             # Convert str based params to the FilePath or Ros...Name format.
-            if self.data_type in [
+            if real_data_type in [
                 RosServiceName,
                 RosTopicName,
                 RosActionName,
                 FilePath,
             ] and isinstance(new_value, str):
-                new_value = self.data_type(new_value)
+                new_value = real_data_type(new_value)
             # Convert Ros...Type from type variables!
-            elif self.data_type in [
+            elif real_data_type in [
                 RosServiceType,
                 RosActionType,
                 RosTopicType,
             ] and isinstance(new_value, type):
                 new_value_type = get_interface_name(new_value)
-                new_value = self.data_type(new_value_type)
+                new_value = real_data_type(new_value_type)
             # Silently convert ints to float
             elif real_data_type == float and isinstance(new_value, int):
                 new_value = float(new_value)

--- a/ros_bt_py/ros_bt_py/node_data.py
+++ b/ros_bt_py/ros_bt_py/node_data.py
@@ -39,6 +39,7 @@ from ros_bt_py.custom_types import (
 )
 from ros_bt_py.helpers import json_encode
 from ros_bt_py.ros_helpers import get_interface_name
+from ros_bt_py.custom_types import TypeWrapper
 
 
 def from_string(data_type, string_value, static=False):
@@ -58,7 +59,7 @@ class NodeData(object):
     update (the initial value, if not empty, counts as an update!)
     """
 
-    def __init__(self, data_type, initial_value=None, static=False):
+    def __init__(self, data_type: type | TypeWrapper, initial_value=None, static=False):
         self.updated = False
         self._value = None
         self._serialized_value = json_encode(None)
@@ -91,12 +92,17 @@ class NodeData(object):
         """Check whether `new_value` has a type that matches this NodeData object."""
         if self._static and self.updated:
             return False
+        
+        if isinstance(self.data_type, TypeWrapper):
+            real_data_type = self.data_type.actual_type
+        else:
+            real_data_type = self.data_type
 
-        if isinstance(new_value, self.data_type) or new_value is None:
+        if isinstance(new_value, real_data_type) or new_value is None:
             return True
 
         # Special case for int and float
-        if self.data_type == float and isinstance(new_value, int):
+        if real_data_type == float and isinstance(new_value, int):
             return True
 
         return False
@@ -113,7 +119,13 @@ class NodeData(object):
         """
         if self._static and self.updated:
             raise Exception("Trying to overwrite data in static NodeData object")
-        if not isinstance(new_value, self.data_type) and new_value is not None:
+        
+        if isinstance(self.data_type, TypeWrapper):
+            real_data_type = self.data_type.actual_type
+        else:
+            real_data_type = self.data_type
+
+        if not isinstance(new_value, real_data_type) and new_value is not None:
             # Convert str based params to the FilePath or Ros...Name format.
             if self.data_type in [
                 RosServiceName,
@@ -131,18 +143,18 @@ class NodeData(object):
                 new_value_type = get_interface_name(new_value)
                 new_value = self.data_type(new_value_type)
             # Silently convert ints to float
-            elif self.data_type == float and isinstance(new_value, int):
+            elif real_data_type == float and isinstance(new_value, int):
                 new_value = float(new_value)
             else:
                 if type(new_value) is dict and "py/type" in new_value:
                     raise TypeError(
-                        f"Expected data to be of type {self.data_type.__name__},"
+                        f"Expected data to be of type {real_data_type.__name__},"
                         f"got {type(new_value).__name__} instead. "
                         f"Looks like failed jsonpickle decode, "
                         f"does type {new_value['py/type']} exist?"
                     )
                 raise TypeError(
-                    f"Expected data to be of type {self.data_type.__name__}, "
+                    f"Expected data to be of type {real_data_type.__name__}, "
                     f"got {type(new_value).__name__} instead"
                 )
         if self._serialized_value is not None and new_value != self._value:

--- a/ros_bt_py/ros_bt_py/nodes/compare.py
+++ b/ros_bt_py/ros_bt_py/nodes/compare.py
@@ -29,7 +29,7 @@ from ros_bt_py_interfaces.msg import Node as NodeMsg
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
-from ros_bt_py.custom_types import HintedType
+from ros_bt_py.custom_types import TypeWrapper, TYPE_BUILTIN
 
 
 @define_bt_node(
@@ -117,7 +117,10 @@ class CompareNewOnly(Leaf):
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"compare_type": HintedType(hints=['builtin']), "expected": OptionRef("compare_type")},
+        options={
+            "compare_type": TypeWrapper(type, info=TYPE_BUILTIN), 
+            "expected": OptionRef("compare_type")
+        },
         inputs={"in": OptionRef("compare_type")},
         outputs={},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/nodes/compare.py
+++ b/ros_bt_py/ros_bt_py/nodes/compare.py
@@ -29,6 +29,7 @@ from ros_bt_py_interfaces.msg import Node as NodeMsg
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
+from ros_bt_py.custom_types import HintedType
 
 
 @define_bt_node(
@@ -116,7 +117,7 @@ class CompareNewOnly(Leaf):
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"compare_type": type, "expected": OptionRef("compare_type")},
+        options={"compare_type": HintedType(hints=['builtin']), "expected": OptionRef("compare_type")},
         inputs={"in": OptionRef("compare_type")},
         outputs={},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/nodes/constant.py
+++ b/ros_bt_py/ros_bt_py/nodes/constant.py
@@ -29,12 +29,13 @@ from ros_bt_py_interfaces.msg import Node as NodeMsg
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
+from ros_bt_py.custom_types import HintedType
 
 
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"constant_type": type, "constant_value": OptionRef("constant_type")},
+        options={"constant_type": HintedType(hints=['builtin']), "constant_value": OptionRef("constant_type")},
         inputs={},
         outputs={"constant": OptionRef("constant_type")},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/nodes/constant.py
+++ b/ros_bt_py/ros_bt_py/nodes/constant.py
@@ -29,13 +29,16 @@ from ros_bt_py_interfaces.msg import Node as NodeMsg
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
-from ros_bt_py.custom_types import HintedType
+from ros_bt_py.custom_types import TypeWrapper, TYPE_BUILTIN
 
 
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"constant_type": HintedType(hints=['builtin']), "constant_value": OptionRef("constant_type")},
+        options={
+            "constant_type": TypeWrapper(type, info=TYPE_BUILTIN), 
+            "constant_value": OptionRef("constant_type")
+        },
         inputs={},
         outputs={"constant": OptionRef("constant_type")},
         max_children=0,
@@ -45,6 +48,9 @@ from ros_bt_py.custom_types import HintedType
 class Constant(Leaf):
     """
     Provide a set value as an output.
+
+    If you're looking to generate Ros Messages, 
+    MessageFromConstDict and other message converters provide a better experience
 
     Useful to provide parameters to Subtrees.
     """

--- a/ros_bt_py/ros_bt_py/nodes/maths.py
+++ b/ros_bt_py/ros_bt_py/nodes/maths.py
@@ -39,8 +39,8 @@ from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
 
-from ros_bt_py.helpers import MathUnaryOperator, MathBinaryOperator
-from ros_bt_py.helpers import MathOperandType, MathUnaryOperandType
+from ros_bt_py.custom_types import MathUnaryOperator, MathBinaryOperator
+from ros_bt_py.custom_types import MathOperandType, MathUnaryOperandType
 
 
 @define_bt_node(

--- a/ros_bt_py/ros_bt_py/package_manager.py
+++ b/ros_bt_py/ros_bt_py/package_manager.py
@@ -41,6 +41,7 @@ import rosidl_runtime_py.utilities
 from ros_bt_py_interfaces.msg import MessageTypes, Package, Packages, Tree
 from ros_bt_py_interfaces.srv import (
     GetMessageFields,
+    GetMessageConstantFields,
     SaveTree,
     GetPackageStructure,
     GetFolderStructure,
@@ -245,8 +246,10 @@ class PackageManager(object):
             )
         return response
 
+    #TODO Maybe instead of introducing a new message type,
+    # constant_fields should also be returned as a dict?
     def get_message_constant_fields_handler(
-        self, request: GetMessageFields.Request, response: GetMessageFields.Response
+        self, request: GetMessageConstantFields.Request, response: GetMessageConstantFields.Response
     ):
         try:
             message_class = rosidl_runtime_py.utilities.get_message(

--- a/ros_bt_py/ros_bt_py/ros_nodes/enum.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/enum.py
@@ -38,7 +38,7 @@ from ros_bt_py.node_config import NodeConfig
 
 from ros_bt_py.ros_helpers import EnumValue, get_message_constant_fields
 
-
+#TODO What does this node do and what should it type input be?
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
@@ -116,6 +116,7 @@ class Enum(Leaf):
         return NodeMsg.IDLE
 
 
+#TODO What does this node do and what should it type input be?
 @define_bt_node(
     NodeConfig(
         version="0.1.0",

--- a/ros_bt_py/ros_bt_py/ros_nodes/file.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/file.py
@@ -34,6 +34,7 @@ from ros_bt_py_interfaces.msg import Node as NodeMsg
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig
+from ros_bt_py.custom_types import FilePath
 
 
 class LoadFileError(Exception):
@@ -74,7 +75,7 @@ def load_file(path):
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"file_path": str},
+        options={"file_path": FilePath},
         inputs={},
         outputs={
             "load_success": bool,
@@ -103,7 +104,7 @@ class YamlListOption(Leaf):
         self.outputs["load_error_msg"] = ""
 
         try:
-            data = load_file(self.options["file_path"])
+            data = load_file(self.options["file_path"].path)
             if data and isinstance(data, list):
                 self.outputs["load_success"] = True
                 self.data = data

--- a/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
@@ -165,6 +165,8 @@ class MessageFromConstDict(Leaf):
     def _do_tick(self):
         message = self._message_type()
         try:
+            #TODO Maybe we should enable using 'auto' headers and 'now' timestamps and
+            # immediately call their respective callbacks?
             set_message_fields(
                 message,
                 self.options["dict"],

--- a/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
@@ -33,8 +33,8 @@ from rclpy.node import Node
 from rosidl_runtime_py.set_message import set_message_fields
 
 from ros_bt_py.node import Leaf, define_bt_node
-from ros_bt_py.node_config import NodeConfig, OptionRef
-from ros_bt_py.custom_types import RosTopicType
+from ros_bt_py.node_config import NodeConfig
+from ros_bt_py.custom_types import RosTopicType, TypeWrapper, DICT_ROS
 from ros_bt_py.debug_manager import DebugManager
 from ros_bt_py.subtree_manager import SubtreeManager
 
@@ -120,7 +120,10 @@ class MessageFromDict(Leaf):
 @define_bt_node(
     NodeConfig(
         version="0.9.0",
-        options={"message_type": RosTopicType, "dict": dict},
+        options={
+            "message_type": RosTopicType, 
+            "dict": TypeWrapper(dict, info=DICT_ROS)
+        },
         inputs={},
         outputs={},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/ros_nodes/param.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/param.py
@@ -31,13 +31,14 @@ from ros_bt_py.exceptions import BehaviorTreeException
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
+from ros_bt_py.custom_types import HintedType
 
 
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
         options={
-            "param_type": type,
+            "param_type": HintedType(hints=['builtin']),
             "default_value": OptionRef("param_type"),
             "param_name": str,
         },
@@ -90,7 +91,7 @@ class RosParamOption(Leaf):
     NodeConfig(
         version="0.1.0",
         options={
-            "param_type": type,
+            "param_type": HintedType(hints=['builtin']),
             "param_name": str,
         },
         inputs={
@@ -145,7 +146,7 @@ class RosParamOptionDefaultInput(Leaf):
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"param_type": type, "default_value": OptionRef("param_type")},
+        options={"param_type": HintedType(hints=['builtin']), "default_value": OptionRef("param_type")},
         inputs={"param_name": str},
         outputs={"param": OptionRef("param_type")},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/ros_nodes/param.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/param.py
@@ -31,14 +31,14 @@ from ros_bt_py.exceptions import BehaviorTreeException
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
-from ros_bt_py.custom_types import HintedType
+from ros_bt_py.custom_types import TypeWrapper, TYPE_BUILTIN
 
 
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
         options={
-            "param_type": HintedType(hints=['builtin']),
+            "param_type": TypeWrapper(type, info=TYPE_BUILTIN),
             "default_value": OptionRef("param_type"),
             "param_name": str,
         },
@@ -91,7 +91,7 @@ class RosParamOption(Leaf):
     NodeConfig(
         version="0.1.0",
         options={
-            "param_type": HintedType(hints=['builtin']),
+            "param_type": TypeWrapper(type, info=TYPE_BUILTIN),
             "param_name": str,
         },
         inputs={
@@ -146,7 +146,10 @@ class RosParamOptionDefaultInput(Leaf):
 @define_bt_node(
     NodeConfig(
         version="0.1.0",
-        options={"param_type": HintedType(hints=['builtin']), "default_value": OptionRef("param_type")},
+        options={
+            "param_type": TypeWrapper(type, info=TYPE_BUILTIN), 
+            "default_value": OptionRef("param_type")
+        },
         inputs={"param_name": str},
         outputs={"param": OptionRef("param_type")},
         max_children=0,

--- a/ros_bt_py/ros_bt_py/tree_node.py
+++ b/ros_bt_py/ros_bt_py/tree_node.py
@@ -69,6 +69,7 @@ from ros_bt_py_interfaces.srv import (
     MorphNode,
     SaveTree,
     GetMessageFields,
+    GetMessageConstantFields,
     GetPackageStructure,
     GenerateSubtree,
     ReloadTree,
@@ -197,7 +198,7 @@ class TreeNode(Node):
             callback_group=self.package_manager_service_callback_group,
         )
         self.get_message_constant_fields_service = self.create_service(
-            GetMessageFields,
+            GetMessageConstantFields,
             "~/get_message_constant_fields",
             callback=self.package_manager.get_message_constant_fields_handler,
             callback_group=self.package_manager_service_callback_group,

--- a/ros_bt_py/tests/test_package_manager.py
+++ b/ros_bt_py/tests/test_package_manager.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import pytest
-from ros_bt_py_interfaces.srv import GetMessageFields
+from ros_bt_py_interfaces.srv import GetMessageConstantFields
 from ros_bt_py.package_manager import PackageManager
 
 from typing import List
@@ -65,11 +65,10 @@ class TestPackageManager:
     def test_get_message_constant_fields_successful(
         self, package_manager: PackageManager, msg_type: str, constant_values: List[str]
     ):
-        request = GetMessageFields.Request()
-        request.service = False
+        request = GetMessageConstantFields.Request()
         request.message_type = msg_type
 
-        response = GetMessageFields.Response()
+        response = GetMessageConstantFields.Response()
         response = package_manager.get_message_constant_fields_handler(
             request=request, response=response
         )
@@ -79,18 +78,6 @@ class TestPackageManager:
         for constant in constant_values:
             assert constant in response.field_names
 
-    def test_get_message_constant_fields_service(self, package_manager: PackageManager):
-        request = GetMessageFields.Request()
-        request.service = True
-
-        response = GetMessageFields.Response()
-        response = package_manager.get_message_constant_fields_handler(
-            request=request, response=response
-        )
-
-        assert response is not None
-        assert not response.success
-        assert len(response.error_message) > 0
 
     @pytest.mark.parametrize(
         "msg_type", ["test_msgs/msg/Bla", "ros_bt_py_interfaces/msg/None"]
@@ -98,11 +85,10 @@ class TestPackageManager:
     def test_get_message_constant_fields_invalid_msgs(
         self, package_manager: PackageManager, msg_type: str
     ):
-        request = GetMessageFields.Request()
+        request = GetMessageConstantFields.Request()
         request.message_type = msg_type
-        request.service = False
 
-        response = GetMessageFields.Response()
+        response = GetMessageConstantFields.Response()
         response = package_manager.get_message_constant_fields_handler(
             request=request, response=response
         )

--- a/ros_bt_py_interfaces/CMakeLists.txt
+++ b/ros_bt_py_interfaces/CMakeLists.txt
@@ -94,6 +94,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetAvailableSubtrees.srv"
   "srv/GetFolderStructure.srv"
   "srv/GetMessageFields.srv"
+  "srv/GetMessageConstantFields.srv"
   "srv/GetPackageStructure.srv"
   "srv/GetStorageFolders.srv"
   "srv/GetSubtree.srv"

--- a/ros_bt_py_interfaces/srv/GetMessageConstantFields.srv
+++ b/ros_bt_py_interfaces/srv/GetMessageConstantFields.srv
@@ -1,0 +1,32 @@
+# Copyright 2023 FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the FZI Forschungszentrum Informatik nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+string message_type
+---
+string[] field_names
+bool success
+string error_message

--- a/ros_bt_py_interfaces/srv/GetMessageFields.srv
+++ b/ros_bt_py_interfaces/srv/GetMessageFields.srv
@@ -25,19 +25,9 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-uint8 MESSAGE=0
-uint8 REQUEST=1
-uint8 RESPONSE=2
-uint8 GOAL=3
-uint8 FEEDBACK=4
-uint8 RESULT=5
-
 string message_type
-bool service
-bool action
-uint8 type
 ---
 string fields
-string[] field_names
+string field_types
 bool success
 string error_message


### PR DESCRIPTION
The new TypeWrapper allows to supply arbitrary information when declaring option types in node configs.

Also updates the get_message_fields Service to provide a recursive dict of message fields and field_types.

This is dependant on 
https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py_web_gui/pull/26

Closes https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py/issues/110

