### PR TITLE
Made documentation look more like the ROS documentation

### DIFF
--- a/ros_bt_py/doc/source/advanced_tutorial.rst
+++ b/ros_bt_py/doc/source/advanced_tutorial.rst
@@ -4,6 +4,11 @@
 Advanced Tutorial
 #################
 
+.. toctree::
+   :maxdepth: 2
+
+   Using OptionRefs
+
 In this Tutorial more advanced concepts are introduced.
 
 ****************

--- a/ros_bt_py/doc/source/basic_tutorial.rst
+++ b/ros_bt_py/doc/source/basic_tutorial.rst
@@ -4,6 +4,18 @@
 Basic Tutorial
 ##############
 
+.. toctree::
+   :maxdepth: 2
+
+   Starting up ros_bt_py
+   Examining the Interface
+   Writing your first BT
+   Working with bt_py
+   Understanding Flow Control
+   Writing a more complex BT
+   Using Subtrees
+   Using ROS Interfaces with ros_bt_py
+
 *********************
 Starting up ros_bt_py
 *********************

--- a/ros_bt_py/doc/source/conf.py
+++ b/ros_bt_py/doc/source/conf.py
@@ -157,12 +157,16 @@ coverage_statistics_to_report = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "furo"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    "show_navbar_depth": 2,
+    "show_toc_level": 2,
+    "collapse_navigation": False,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/ros_bt_py/doc/source/configuration.rst
+++ b/ros_bt_py/doc/source/configuration.rst
@@ -1,0 +1,8 @@
+Configuration & Utilities
+==========================
+
+.. toctree::
+   :maxdepth: 1
+
+   advanced_launch_configuration
+   utility_functions

--- a/ros_bt_py/doc/source/creating_a_node_class_package.rst
+++ b/ros_bt_py/doc/source/creating_a_node_class_package.rst
@@ -4,6 +4,12 @@
 Creating a Node Class package
 #############################
 
+.. toctree::
+   :maxdepth: 2
+
+   Package Creation
+   Example Package
+
 When adding more complex node classes it is strongly advised, that you create your own Python
 package for them, so you don't have to fork (or even have uncommited changes!!) in your
 ``ros_bt_py`` repository.

--- a/ros_bt_py/doc/source/creating_node_classes.rst
+++ b/ros_bt_py/doc/source/creating_node_classes.rst
@@ -4,6 +4,14 @@
 Creating Node Classes
 #####################
 
+.. toctree::
+   :maxdepth: 2
+
+   1. Create a new class
+   2. Fill in the NodeConfig
+   3. Implement the :code:`_do_` methods
+   4. Test your node!
+
 Say you are building a Behavior Tree, and want to do something more
 complex than the node classes in ``ros_bt_py.nodes`` or
 ``ros_bt_py.ros_nodes`` can support.

--- a/ros_bt_py/doc/source/getting_started.rst
+++ b/ros_bt_py/doc/source/getting_started.rst
@@ -2,6 +2,12 @@
 Getting Started
 ###############
 
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   running_ros_bt_py
+
 ************
 Installation
 ************

--- a/ros_bt_py/doc/source/index.rst
+++ b/ros_bt_py/doc/source/index.rst
@@ -46,26 +46,53 @@ ros_bt_py was created with the following goals in mind:
 
 It is meant as a high level control option similar to SMACH or FlexBE.
 
-*****************
-Table of Contents
-*****************
+*************************
+Getting Started
+*************************
 
 .. toctree::
-    :maxdepth: 2
+   :maxdepth: 2
 
-    getting_started
-    basic_tutorial
-    advanced_tutorial
-    creating_a_node_class_package
-    creating_node_classes
-    testing_node_classes
-    advanced_launch_configuration
-    utility_functions
-    api
+   getting_started
 
+*************************
+Tutorials
+*************************
+
+.. toctree::
+   :maxdepth: 2
+
+   tutorials
+
+*********************
+Custom Node Creation
+*********************
+
+.. toctree::
+   :maxdepth: 2
+
+   node_creation
+
+**************************
+Configuration & Utilities
+**************************
+
+.. toctree::
+   :maxdepth: 2
+
+   configuration
+
+*************
+API Reference
+*************
+
+.. toctree::
+   :maxdepth: 2
+
+   api
 
 ******************
-Indices and tables
+Indices and Tables
 ******************
 
 * :ref:`genindex`

--- a/ros_bt_py/doc/source/node_creation.rst
+++ b/ros_bt_py/doc/source/node_creation.rst
@@ -1,0 +1,9 @@
+Creating Nodes
+==============
+
+.. toctree::
+   :maxdepth: 1
+
+   creating_a_node_class_package
+   creating_node_classes
+   testing_node_classes

--- a/ros_bt_py/doc/source/testing_node_classes.rst
+++ b/ros_bt_py/doc/source/testing_node_classes.rst
@@ -4,6 +4,15 @@
 Testing Node Classes
 ####################
 
+.. toctree::
+   :maxdepth: 2
+
+   Creating a Test Folder and Unit Test Script
+   Running your Unit Tests
+   Adding your Unit Tests to CMakeLists.txt
+   Adding your Unit Tests to setup.py
+   Running Tests via colcon
+
 Even though a lot of errors are harder to make and/or easier to catch
 with :mod:`ros_bt_py` than with other libraries, you should still
 test any new node classes you make.

--- a/ros_bt_py/doc/source/tutorials.rst
+++ b/ros_bt_py/doc/source/tutorials.rst
@@ -1,0 +1,16 @@
+Tutorials
+=========
+
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Basic Tutorial
+
+   basic_tutorial
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Advanced Tutorial
+
+   advanced_tutorial


### PR DESCRIPTION
Made the documentation look more like the ROS documentation by changing the theme to `sphinx_rtd_theme` and changing the left side bar.
Closes #115 

![documentation_showcase](https://github.com/user-attachments/assets/6a2caa02-503a-4a06-af84-9df5c378b277)
