### PR TITLE
Tree load and save updates

### DIFF
--- a/ros_bt_py/ros_bt_py/package_manager.py
+++ b/ros_bt_py/ros_bt_py/package_manager.py
@@ -149,6 +149,9 @@ class PackageManager(object):
                         response.file_path = split_save_filepath
                         return response
 
+            # Set path to blank, this value not be persisted
+            request.tree.path = ""
+
             with open(split_save_filepath, "w") as save_file:
                 msg = rosidl_runtime_py.message_to_yaml(request.tree)
                 save_file.write(msg)

--- a/ros_bt_py/ros_bt_py/tree_manager.py
+++ b/ros_bt_py/ros_bt_py/tree_manager.py
@@ -180,7 +180,6 @@ def load_tree_from_file(
 ) -> MigrateTree.Response:
     """Load a tree file from disk."""
     tree = request.tree
-    file_name = ""
     while not tree.nodes:
         file_path = ""
         if not tree.path:
@@ -220,7 +219,6 @@ def load_tree_from_file(
             return response
 
         with tree_file:
-            file_name = os.path.basename(tree_file.name)
             tree_yaml = tree_file.read()
             try:
                 response = parse_tree_yaml(tree_yaml=tree_yaml)


### PR DESCRIPTION
Update the load and save functions to properly persist the user-given name for a tree.

Fix the rename on save function to actually use the updated filename.

Set the `tree.path` field to the path of the file we're loading from.
It's important to set this dynamically since the file could've been moved since the last save.
The new save implementation clears the `tree.path` field for this reason.
