### PR TITLE
Fix Fallback node and add tests

### DIFF
--- a/ros_bt_py/ros_bt_py/node.py
+++ b/ros_bt_py/ros_bt_py/node.py
@@ -38,6 +38,7 @@ import importlib
 import inspect
 import re
 from typing import (
+    TypeVar,
     Any,
     Callable,
     Generator,
@@ -118,8 +119,11 @@ def _connect_wirings(data_wirings: List[Wiring], type: str) -> Dict[str, List[st
     return connected_wirings
 
 
+N = TypeVar("N", bound="Node")
+
+
 @typechecked
-def define_bt_node(node_config: NodeConfig) -> Callable[[Type["Node"]], Type["Node"]]:
+def define_bt_node(node_config: NodeConfig) -> Callable[[type[N]], type[N]]:
     """
     Provide information about this Node's interface.
 
@@ -133,7 +137,7 @@ def define_bt_node(node_config: NodeConfig) -> Callable[[Type["Node"]], Type["No
     class. You should not need to register anything manually!
     """
 
-    def inner_dec(node_class: Type[Node]) -> Type[Node]:
+    def inner_dec(node_class: type[N]) -> type[N]:
         # Merge supplied node config with those of base classes
         for base in node_class.__bases__:
             if hasattr(base, "_node_config") and base._node_config:

--- a/ros_bt_py/ros_bt_py/nodes/fallback.py
+++ b/ros_bt_py/ros_bt_py/nodes/fallback.py
@@ -126,9 +126,11 @@ class Fallback(FlowControl):
 
     def _do_setup(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.setup()
-            if result.is_err():
-                return result
+            match child.setup():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_tick(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -139,42 +141,49 @@ class Fallback(FlowControl):
         # If we've previously succeeded or failed, untick all children
         if self.state in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
             for child in self.children:
-                result = child.reset()
-                if result.is_err():
-                    return result
+                match child.reset():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         # Tick children until one returns SUCCEEDED or RUNNING
         for index, child in enumerate(self.children):
-            result = child.tick()
-            if result.is_err():
-                return result
-            if (
-                result.ok() == BTNodeState.SUCCEEDED
-                or result.ok() == BTNodeState.RUNNING
-            ):
-                if result.ok() == BTNodeState.SUCCEEDED:
+            match child.tick():
+                case Err(e):
+                    return Err(e)
+                case Ok(s):
+                    state = s
+            if state in [BTNodeState.SUCCEEDED, BTNodeState.RUNNING]:
+                if state == BTNodeState.SUCCEEDED:
                     # untick all children after the one that triggered this
                     # condition
                     for untick_child in self.children[index + 1 :]:
-                        result = untick_child.untick()
-                        if result.is_err():
-                            return result
-                return result
+                        match untick_child.untick():
+                            case Err(e):
+                                return Err(e)
+                            case Ok(_):
+                                pass
+                return Ok(state)
         # If all children failed, we too fail
         return Ok(BTNodeState.FAILED)
 
     def _do_untick(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.untick()
-            if result.is_err():
-                return result
+            match child.untick():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_reset(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.reset()
-            if result.is_err():
-                return result
+            match child.reset():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_shutdown(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -224,12 +233,16 @@ class MemoryFallback(FlowControl):
     return FAILED.
     """
 
+    last_running_child: int
+
     def _do_setup(self) -> Result[BTNodeState, BehaviorTreeException]:
         self.last_running_child = 0
         for child in self.children:
-            result = child.setup()
-            if result.is_err():
-                return result
+            match child.setup():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_tick(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -242,45 +255,54 @@ class MemoryFallback(FlowControl):
         if self.state in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
             self.last_running_child = 0
             for child in self.children:
-                result = child.reset()
-                if result.is_err():
-                    return result
+                match child.reset():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         # Tick children until one returns SUCCEEDED or RUNNING
         for index, child in enumerate(self.children):
             if index < self.last_running_child:
                 continue
-            result = child.tick()
-            if (
-                result.ok() == BTNodeState.SUCCEEDED
-                or result.ok() == BTNodeState.RUNNING
-            ):
-                if result.ok() == BTNodeState.RUNNING:
+            match child.tick():
+                case Err(e):
+                    return Err(e)
+                case Ok(s):
+                    state = s
+            if state in [BTNodeState.SUCCEEDED, BTNodeState.RUNNING]:
+                if state == BTNodeState.RUNNING:
                     self.last_running_child = index
-                elif result.ok() == BTNodeState.SUCCEEDED:
+                elif state == BTNodeState.SUCCEEDED:
                     # untick all children after the one that triggered this
                     # condition
                     for untick_child in self.children[index + 1 :]:
-                        result = untick_child.untick()
-                        if result.is_err():
-                            return result
-                return result
+                        match untick_child.untick():
+                            case Err(e):
+                                return Err(e)
+                            case Ok(_):
+                                pass
+                return Ok(state)
         # If all children failed, we too fail
         return Ok(BTNodeState.FAILED)
 
     def _do_untick(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.untick()
-            if result.is_err():
-                return result
+            match child.untick():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         self.last_running_child = 0
         return Ok(BTNodeState.IDLE)
 
     def _do_reset(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.reset()
-            if result.is_err():
-                return result
+            match child.reset():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         self.last_running_child = 0
         return Ok(BTNodeState.IDLE)
 

--- a/ros_bt_py/ros_bt_py/nodes/fallback.py
+++ b/ros_bt_py/ros_bt_py/nodes/fallback.py
@@ -44,9 +44,11 @@ class NameSwitch(FlowControl):
     def _do_setup(self) -> Result[BTNodeState, BehaviorTreeException]:
         self.child_map = {child.name.split(".")[-1]: child for child in self.children}
         for child in self.children:
-            result = child.setup()
-            if result.is_err():
-                return result
+            match child.setup():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_tick(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -55,33 +57,41 @@ class NameSwitch(FlowControl):
             self.logwarn("Ticking without children. Is this really what you want?")
             return Ok(BTNodeState.FAILED)
 
-        # If we've previously succeeded or failed, untick all children
+        # If we've previously succeeded or failed, reset all children
         if self.state in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
             for child in self.children:
-                result = child.reset()
-                if result.is_err():
-                    return result
+                match child.reset():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         for child_name, child in self.child_map.items():
             if not child_name == name:
-                result = child.untick()
-                if result.is_err():
-                    return result
+                match child.untick():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         return self.child_map[name].tick()
 
     def _do_untick(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.untick()
-            if result.is_err():
-                return result
+            match child.untick():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_reset(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.reset()
-            if result.is_err():
-                return result
+            match child.reset():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_shutdown(self) -> Result[BTNodeState, BehaviorTreeException]:

--- a/ros_bt_py/ros_bt_py/nodes/parallel.py
+++ b/ros_bt_py/ros_bt_py/nodes/parallel.py
@@ -79,9 +79,11 @@ class Parallel(FlowControl):
                 )
             )
         for child in self.children:
-            result = child.setup()
-            if result.is_err():
-                return result
+            match child.setup():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_tick(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -89,17 +91,21 @@ class Parallel(FlowControl):
         # SUCCEEDED or FAILED once
         if self.state in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
             for child in self.children:
-                result = child.reset()
-                if result.is_err():
-                    return result
+                match child.reset():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         successes = 0
         failures = 0
         for child in self.children:
             if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                result = child.tick()
-                if result.is_err():
-                    return result
+                match child.tick():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
             if child.state == BTNodeState.SUCCEEDED:
                 successes += 1
             if child.state == BTNodeState.FAILED:
@@ -108,17 +114,21 @@ class Parallel(FlowControl):
             # untick all running children
             for child in self.children:
                 if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                    result = child.untick()
-                    if result.is_err():
-                        return result
+                    match child.untick():
+                        case Err(e):
+                            return Err(e)
+                        case Ok(_):
+                            pass
             return Ok(BTNodeState.SUCCEEDED)
         elif failures > len(self.children) - self.options["needed_successes"]:
             # untick all running children
             for child in self.children:
                 if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                    result = child.untick()
-                    if result.is_err():
-                        return result
+                    match child.untick():
+                        case Err(e):
+                            return Err(e)
+                        case Ok(_):
+                            pass
             return Ok(BTNodeState.FAILED)
         return Ok(BTNodeState.RUNNING)
 
@@ -127,16 +137,20 @@ class Parallel(FlowControl):
 
     def _do_reset(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.reset()
-            if result.is_err():
-                return result
+            match child.reset():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_untick(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.untick()
-            if result.is_err():
-                return result
+            match child.untick():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_calculate_utility(self) -> Result[UtilityBounds, BehaviorTreeException]:
@@ -286,9 +300,11 @@ class ParallelFailureTolerance(FlowControl):
                 )
             )
         for child in self.children:
-            result = child.setup()
-            if result.is_err():
-                return result
+            match child.setup():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_tick(self) -> Result[BTNodeState, BehaviorTreeException]:
@@ -296,17 +312,21 @@ class ParallelFailureTolerance(FlowControl):
         # SUCCEEDED or FAILED once
         if self.state in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
             for child in self.children:
-                result = child.reset()
-                if result.is_err():
-                    return result
+                match child.reset():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
 
         successes = 0
         failures = 0
         for child in self.children:
             if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                result = child.tick()
-                if result.is_err():
-                    return result
+                match child.tick():
+                    case Err(e):
+                        return Err(e)
+                    case Ok(_):
+                        pass
             if child.state == BTNodeState.SUCCEEDED:
                 successes += 1
             if child.state == BTNodeState.FAILED:
@@ -315,17 +335,21 @@ class ParallelFailureTolerance(FlowControl):
             # untick all running children
             for child in self.children:
                 if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                    result = child.untick()
-                    if result.is_err():
-                        return result
+                    match child.untick():
+                        case Err(e):
+                            return Err(e)
+                        case Ok(_):
+                            pass
             return Ok(BTNodeState.SUCCEEDED)
         elif failures > self.options["tolerate_failures"]:
             # untick all running children
             for child in self.children:
                 if child.state not in [BTNodeState.SUCCEEDED, BTNodeState.FAILED]:
-                    result = child.untick()
-                    if result.is_err():
-                        return result
+                    match child.untick():
+                        case Err(e):
+                            return Err(e)
+                        case Ok(_):
+                            pass
             return Ok(BTNodeState.FAILED)
         return Ok(BTNodeState.RUNNING)
 
@@ -334,16 +358,20 @@ class ParallelFailureTolerance(FlowControl):
 
     def _do_reset(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.reset()
-            if result.is_err():
-                return result
+            match child.reset():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_untick(self) -> Result[BTNodeState, BehaviorTreeException]:
         for child in self.children:
-            result = child.untick()
-            if result.is_err():
-                return result
+            match child.untick():
+                case Err(e):
+                    return Err(e)
+                case Ok(_):
+                    pass
         return Ok(BTNodeState.IDLE)
 
     def _do_calculate_utility(self) -> Result[UtilityBounds, BehaviorTreeException]:

--- a/ros_bt_py/tests/nodes/test_fallback.py
+++ b/ros_bt_py/tests/nodes/test_fallback.py
@@ -37,32 +37,36 @@ from ros_bt_py.nodes.fallback import Fallback, MemoryFallback, NameSwitch
 
 
 @pytest.fixture
-def mock_node() -> mock.NonCallableMagicMock:
-    mock_node = mock.NonCallableMagicMock(set=Node)
-    mock_node.setup.return_value = Ok(BTNodeState.IDLE)
-    mock_node.tick.return_value = Ok(BTNodeState.FAILED)
-    mock_node.untick.return_value = Ok(BTNodeState.IDLE)
-    mock_node.reset.return_value = Ok(BTNodeState.IDLE)
-    mock_node.shutdown.return_value = Ok(BTNodeState.SHUTDOWN)
-    return mock_node
+def mock_obj() -> mock.NonCallableMagicMock:
+    mock_obj = mock.NonCallableMagicMock()
+    mock_obj.children = []
+    for i in range(1, 4):
+        mock_node = mock.NonCallableMagicMock(set=Node)
+        mock_node.setup.return_value = Ok(BTNodeState.IDLE)
+        mock_node.tick.return_value = Ok(BTNodeState.FAILED)
+        mock_node.untick.return_value = Ok(BTNodeState.IDLE)
+        mock_node.reset.return_value = Ok(BTNodeState.IDLE)
+        mock_node.shutdown.return_value = Ok(BTNodeState.SHUTDOWN)
+        setattr(mock_obj, f"child{i}", mock_node)
+        mock_obj.children.append(mock_node)
+    return mock_obj
 
 
 class TestFallback:
 
     @pytest.fixture
-    def target_node(self) -> Fallback:
+    def target_node(self, mock_obj: mock.NonCallableMagicMock) -> Fallback:
         node = Fallback()
+        # We add node children directly to avoid node additional checks
+        node.children = mock_obj.children
         node.state = BTNodeState.IDLE
         return node
 
     def test_setup(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid additional checks
-        target_node.children = mock_children  # type: ignore
         # Node has to be shutdown to call setup
         target_node.state = BTNodeState.SHUTDOWN
 
@@ -71,33 +75,31 @@ class TestFallback:
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.setup()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.setup(),
+            mock.call.child2.setup(),
+            mock.call.child3.setup(),
+        ]
 
     def test_tick_success(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
-        mock_child_3 = deepcopy(mock_node)
-        # We add node children directly to avoid additional checks
-        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
 
         result = target_node.tick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.SUCCEEDED
         assert target_node.state == BTNodeState.SUCCEEDED
 
-        assert mock_child_1.mock_calls == [mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == [mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.untick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
-        mock_child_3.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -105,35 +107,33 @@ class TestFallback:
         assert result.unwrap() == BTNodeState.SUCCEEDED
         assert target_node.state == BTNodeState.SUCCEEDED
 
-        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
-        assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.untick(),
+        ]
 
     def test_tick_running(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
-        mock_child_3 = deepcopy(mock_node)
-
-        # We add node children directly to avoid node additional checks
-        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.RUNNING)
 
         result = target_node.tick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.RUNNING
         assert target_node.state == BTNodeState.RUNNING
 
-        assert mock_child_1.mock_calls == [mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == []
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
-        mock_child_3.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should NOT involve a reset on all child nodes
         result = target_node.tick()
@@ -141,29 +141,28 @@ class TestFallback:
         assert result.unwrap() == BTNodeState.RUNNING
         assert target_node.state == BTNodeState.RUNNING
 
-        assert mock_child_1.mock_calls == [mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == []
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+        ]
 
     def test_tick_failure(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.tick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.FAILED
         assert target_node.state == BTNodeState.FAILED
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.tick(),
+        ]
 
-        for m_c in mock_children:
-            m_c.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -171,49 +170,55 @@ class TestFallback:
         assert result.unwrap() == BTNodeState.FAILED
         assert target_node.state == BTNodeState.FAILED
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.tick(),
+        ]
 
     def test_untick(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.untick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child2.untick(),
+            mock.call.child3.untick(),
+        ]
 
     def test_reset(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.reset()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.reset()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+        ]
 
 
 class TestMemoryFallback:
 
     @pytest.fixture
-    def target_node(self) -> MemoryFallback:
+    def target_node(self, mock_obj: mock.NonCallableMagicMock) -> MemoryFallback:
         node = MemoryFallback()
+        # We add node children directly to avoid node additional checks
+        node.children = mock_obj.children
         node.state = BTNodeState.IDLE
         node.last_running_child = -1
         return node
@@ -221,11 +226,8 @@ class TestMemoryFallback:
     def test_setup(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid additional checks
-        target_node.children = mock_children  # type: ignore
         # Node has to be shutdown to call setup
         target_node.state = BTNodeState.SHUTDOWN
 
@@ -235,20 +237,18 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.IDLE
         assert target_node.last_running_child == 0
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.setup()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.setup(),
+            mock.call.child2.setup(),
+            mock.call.child3.setup(),
+        ]
 
     def test_tick_success(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
-        mock_child_3 = deepcopy(mock_node)
-        # We add node children directly to avoid additional checks
-        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
 
         result = target_node.tick()
         assert result.is_ok()
@@ -256,13 +256,13 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.SUCCEEDED
         assert target_node.last_running_child == -1
 
-        assert mock_child_1.mock_calls == [mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == [mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.untick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
-        mock_child_3.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -271,22 +271,21 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.SUCCEEDED
         assert target_node.last_running_child == 0
 
-        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
-        assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.untick(),
+        ]
 
     def test_tick_running(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
-        mock_child_3 = deepcopy(mock_node)
-
-        # We add node children directly to avoid node additional checks
-        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.RUNNING)
 
         result = target_node.tick()
         assert result.is_ok()
@@ -294,13 +293,12 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.RUNNING
         assert target_node.last_running_child == 1
 
-        assert mock_child_1.mock_calls == [mock.call.tick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == []
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
-        mock_child_3.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should NOT involve a reset on all child nodes
         result = target_node.tick()
@@ -309,30 +307,28 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.RUNNING
         assert target_node.last_running_child == 1
 
-        assert mock_child_1.mock_calls == []
-        assert mock_child_2.mock_calls == [mock.call.tick()]
-        assert mock_child_3.mock_calls == []
+        assert mock_obj.method_calls == [
+            mock.call.child2.tick(),
+        ]
 
     def test_tick_failure(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.tick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.FAILED
         assert target_node.state == BTNodeState.FAILED
         assert target_node.last_running_child == -1
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.tick(),
+        ]
 
-        for m_c in mock_children:
-            m_c.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -341,86 +337,94 @@ class TestMemoryFallback:
         assert target_node.state == BTNodeState.FAILED
         assert target_node.last_running_child == 0
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.tick(),
+            mock.call.child2.tick(),
+            mock.call.child3.tick(),
+        ]
 
     def test_untick(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.untick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
         assert target_node.last_running_child == 0
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child2.untick(),
+            mock.call.child3.untick(),
+        ]
 
     def test_reset(
         self,
         target_node: MemoryFallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.reset()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
         assert target_node.last_running_child == 0
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.reset()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+        ]
 
 
 class TestNameSwitch:
 
     @pytest.fixture
-    def target_node(self) -> NameSwitch:
+    def target_node(self, mock_obj: mock.NonCallableMagicMock) -> NameSwitch:
         node = NameSwitch()
+        # We add node children directly to avoid node additional checks
+        node.children = mock_obj.children
+        node.child_map = {
+            f"child{i + 1}": child for i, child in enumerate(mock_obj.children)
+        }
         node.state = BTNodeState.IDLE
         return node
 
     def test_setup(
         self,
         target_node: NameSwitch,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        for i, m_c in enumerate(mock_children):
+        for i, m_c in enumerate(mock_obj.children):
             m_c.name = f"child{i}"
-        # We add node children directly to avoid additional checks
-        target_node.children = mock_children  # type: ignore
         # Node has to be shutdown to call setup
         target_node.state = BTNodeState.SHUTDOWN
+        target_node.child_map = {}
 
         result = target_node.setup()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
+        assert target_node.child_map == {
+            f"child{i}": m_c for i, m_c in enumerate(mock_obj.children)
+        }
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.setup()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.setup(),
+            mock.call.child2.setup(),
+            mock.call.child3.setup(),
+        ]
 
     def test_tick_success(
         self,
         target_node: NameSwitch,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
-        # We add node children directly to avoid additional checks
-        target_node.children = [mock_child_1, mock_child_2]
-        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
         target_node.inputs["name"] = "child2"
 
         result = target_node.tick()
@@ -428,11 +432,13 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.SUCCEEDED
         assert target_node.state == BTNodeState.SUCCEEDED
 
-        assert mock_child_1.mock_calls == [mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -440,20 +446,21 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.SUCCEEDED
         assert target_node.state == BTNodeState.SUCCEEDED
 
-        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
     def test_tick_running(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
-        # We add node children directly to avoid additional checks
-        target_node.children = [mock_child_1, mock_child_2]
-        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
+        mock_obj.child2.tick.return_value = Ok(BTNodeState.RUNNING)
         target_node.inputs["name"] = "child2"
 
         result = target_node.tick()
@@ -461,11 +468,13 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.RUNNING
         assert target_node.state == BTNodeState.RUNNING
 
-        assert mock_child_1.mock_calls == [mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should NOT involve a reset on all child nodes
         result = target_node.tick()
@@ -473,19 +482,17 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.RUNNING
         assert target_node.state == BTNodeState.RUNNING
 
-        assert mock_child_1.mock_calls == [mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
     def test_tick_failure(
         self,
         target_node: Fallback,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_child_1 = deepcopy(mock_node)
-        mock_child_2 = deepcopy(mock_node)
-        # We add node children directly to avoid additional checks
-        target_node.children = [mock_child_1, mock_child_2]
-        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
         target_node.inputs["name"] = "child2"
 
         result = target_node.tick()
@@ -493,11 +500,13 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.FAILED
         assert target_node.state == BTNodeState.FAILED
 
-        assert mock_child_1.mock_calls == [mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
-        mock_child_1.reset_mock()
-        mock_child_2.reset_mock()
+        mock_obj.reset_mock()
 
         # The second tick should also involve a reset on all child nodes
         result = target_node.tick()
@@ -505,39 +514,43 @@ class TestNameSwitch:
         assert result.unwrap() == BTNodeState.FAILED
         assert target_node.state == BTNodeState.FAILED
 
-        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.untick()]
-        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+            mock.call.child1.untick(),
+            mock.call.child3.untick(),
+            mock.call.child2.tick(),
+        ]
 
     def test_untick(
         self,
         target_node: NameSwitch,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.untick()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.untick()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.untick(),
+            mock.call.child2.untick(),
+            mock.call.child3.untick(),
+        ]
 
     def test_reset(
         self,
         target_node: NameSwitch,
-        mock_node: mock.NonCallableMagicMock,
+        mock_obj: mock.NonCallableMagicMock,
     ):
-        mock_children = [deepcopy(mock_node) for _ in range(3)]
-        # We add node children directly to avoid node additional checks
-        target_node.children = mock_children  # type: ignore
-
         result = target_node.reset()
         assert result.is_ok()
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
 
-        for m_c in mock_children:
-            assert m_c.mock_calls == [mock.call.reset()]
+        assert mock_obj.method_calls == [
+            mock.call.child1.reset(),
+            mock.call.child2.reset(),
+            mock.call.child3.reset(),
+        ]

--- a/ros_bt_py/tests/nodes/test_fallback.py
+++ b/ros_bt_py/tests/nodes/test_fallback.py
@@ -33,12 +33,12 @@ from result import Result, Ok, Err
 
 from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.node import Node
-from ros_bt_py.nodes.fallback import Fallback, MemoryFallback
+from ros_bt_py.nodes.fallback import Fallback, MemoryFallback, NameSwitch
 
 
 @pytest.fixture
 def mock_node() -> mock.NonCallableMagicMock:
-    mock_node = mock.NonCallableMagicMock(spec_set=Node)
+    mock_node = mock.NonCallableMagicMock(set=Node)
     mock_node.setup.return_value = Ok(BTNodeState.IDLE)
     mock_node.tick.return_value = Ok(BTNodeState.FAILED)
     mock_node.untick.return_value = Ok(BTNodeState.IDLE)
@@ -55,7 +55,11 @@ class TestFallback:
         node.state = BTNodeState.IDLE
         return node
 
-    def test_setup(self, target_node: Fallback, mock_node: mock.NonCallableMagicMock):
+    def test_setup(
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
+    ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid additional checks
         target_node.children = mock_children  # type: ignore
@@ -71,7 +75,9 @@ class TestFallback:
             assert m_c.mock_calls == [mock.call.setup()]
 
     def test_tick_success(
-        self, target_node: Fallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_child_1 = deepcopy(mock_node)
         mock_child_2 = deepcopy(mock_node)
@@ -104,7 +110,9 @@ class TestFallback:
         assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
 
     def test_tick_running(
-        self, target_node: Fallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_child_1 = deepcopy(mock_node)
         mock_child_2 = deepcopy(mock_node)
@@ -138,7 +146,9 @@ class TestFallback:
         assert mock_child_3.mock_calls == []
 
     def test_tick_failure(
-        self, target_node: Fallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
@@ -164,7 +174,11 @@ class TestFallback:
         for m_c in mock_children:
             assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
 
-    def test_untick(self, target_node: Fallback, mock_node: mock.NonCallableMagicMock):
+    def test_untick(
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
+    ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
         target_node.children = mock_children  # type: ignore
@@ -177,7 +191,11 @@ class TestFallback:
         for m_c in mock_children:
             assert m_c.mock_calls == [mock.call.untick()]
 
-    def test_reset(self, target_node: Fallback, mock_node: mock.NonCallableMagicMock):
+    def test_reset(
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
+    ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
         target_node.children = mock_children  # type: ignore
@@ -201,7 +219,9 @@ class TestMemoryFallback:
         return node
 
     def test_setup(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid additional checks
@@ -219,7 +239,9 @@ class TestMemoryFallback:
             assert m_c.mock_calls == [mock.call.setup()]
 
     def test_tick_success(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_child_1 = deepcopy(mock_node)
         mock_child_2 = deepcopy(mock_node)
@@ -254,7 +276,9 @@ class TestMemoryFallback:
         assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
 
     def test_tick_running(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_child_1 = deepcopy(mock_node)
         mock_child_2 = deepcopy(mock_node)
@@ -290,7 +314,9 @@ class TestMemoryFallback:
         assert mock_child_3.mock_calls == []
 
     def test_tick_failure(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
@@ -319,7 +345,9 @@ class TestMemoryFallback:
             assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
 
     def test_untick(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
@@ -335,7 +363,9 @@ class TestMemoryFallback:
             assert m_c.mock_calls == [mock.call.untick()]
 
     def test_reset(
-        self, target_node: MemoryFallback, mock_node: mock.NonCallableMagicMock
+        self,
+        target_node: MemoryFallback,
+        mock_node: mock.NonCallableMagicMock,
     ):
         mock_children = [deepcopy(mock_node) for _ in range(3)]
         # We add node children directly to avoid node additional checks
@@ -346,6 +376,168 @@ class TestMemoryFallback:
         assert result.unwrap() == BTNodeState.IDLE
         assert target_node.state == BTNodeState.IDLE
         assert target_node.last_running_child == 0
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset()]
+
+
+class TestNameSwitch:
+
+    @pytest.fixture
+    def target_node(self) -> NameSwitch:
+        node = NameSwitch()
+        node.state = BTNodeState.IDLE
+        return node
+
+    def test_setup(
+        self,
+        target_node: NameSwitch,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        for i, m_c in enumerate(mock_children):
+            m_c.name = f"child{i}"
+        # We add node children directly to avoid additional checks
+        target_node.children = mock_children  # type: ignore
+        # Node has to be shutdown to call setup
+        target_node.state = BTNodeState.SHUTDOWN
+
+        result = target_node.setup()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.setup()]
+
+    def test_tick_success(
+        self,
+        target_node: NameSwitch,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+        # We add node children directly to avoid additional checks
+        target_node.children = [mock_child_1, mock_child_2]
+        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
+        target_node.inputs["name"] = "child2"
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+
+        # The second tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+
+    def test_tick_running(
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
+        # We add node children directly to avoid additional checks
+        target_node.children = [mock_child_1, mock_child_2]
+        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
+        target_node.inputs["name"] = "child2"
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+
+        # The second tick should NOT involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+
+    def test_tick_failure(
+        self,
+        target_node: Fallback,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        # We add node children directly to avoid additional checks
+        target_node.children = [mock_child_1, mock_child_2]
+        target_node.child_map = {"child1": mock_child_1, "child2": mock_child_2}  # type: ignore
+        target_node.inputs["name"] = "child2"
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+
+        # The second tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.untick()]
+        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+
+    def test_untick(
+        self,
+        target_node: NameSwitch,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.untick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.untick()]
+
+    def test_reset(
+        self,
+        target_node: NameSwitch,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.reset()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
 
         for m_c in mock_children:
             assert m_c.mock_calls == [mock.call.reset()]

--- a/ros_bt_py/tests/nodes/test_parallel.py
+++ b/ros_bt_py/tests/nodes/test_parallel.py
@@ -1,0 +1,448 @@
+# Copyright 2025 FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the FZI Forschungszentrum Informatik nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import pytest
+import unittest.mock as mock
+
+from copy import deepcopy
+from result import Result, Ok, Err
+
+from ros_bt_py.helpers import BTNodeState
+from ros_bt_py.node import Node
+from ros_bt_py.nodes.parallel import Parallel, ParallelFailureTolerance
+
+
+@pytest.fixture
+def mock_node() -> mock.NonCallableMagicMock:
+    mock_node = mock.NonCallableMagicMock(set=Node)
+    mock_node.state = BTNodeState.RUNNING
+    mock_node.setup.return_value = Ok(BTNodeState.IDLE)
+    mock_node.tick.return_value = Ok(BTNodeState.RUNNING)
+    mock_node.untick.return_value = Ok(BTNodeState.IDLE)
+    mock_node.reset.return_value = Ok(BTNodeState.IDLE)
+    mock_node.shutdown.return_value = Ok(BTNodeState.SHUTDOWN)
+    return mock_node
+
+
+class TestParallel:
+
+    @pytest.fixture
+    def target_node(self) -> Parallel:
+        node = Parallel(options={"needed_successes": 2})
+        node.state = BTNodeState.IDLE
+        return node
+
+    def test_setup(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid additional checks
+        target_node.children = mock_children  # type: ignore
+        # Node has to be shutdown to call setup
+        target_node.state = BTNodeState.SHUTDOWN
+
+        result = target_node.setup()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.setup()]
+
+    def test_tick_success(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.state = BTNodeState.SUCCEEDED
+        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        mock_child_3.state = BTNodeState.SUCCEEDED
+        mock_child_3.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [mock.call.tick(), mock.call.untick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == []
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        # The next tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [
+            mock.call.reset(),
+            mock.call.tick(),
+            mock.call.untick(),
+        ]
+        assert mock_child_2.mock_calls == [mock.call.reset()]
+        assert mock_child_3.mock_calls == [mock.call.reset()]
+
+    def test_tick_running(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+        for m_c in mock_children:
+            m_c.reset_mock()
+
+        # The second tick should NOT involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+    def test_tick_failure(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.state = BTNodeState.FAILED
+        mock_child_2.tick.return_value = Ok(BTNodeState.FAILED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        mock_child_3.state = BTNodeState.FAILED
+        mock_child_3.tick.return_value = Ok(BTNodeState.FAILED)
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.tick(), mock.call.untick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == []
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        # The next tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [
+            mock.call.reset(),
+            mock.call.tick(),
+            mock.call.untick(),
+        ]
+        assert mock_child_2.mock_calls == [mock.call.reset()]
+        assert mock_child_3.mock_calls == [mock.call.reset()]
+
+    def test_untick(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.untick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.untick()]
+
+    def test_reset(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.reset()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset()]
+
+
+class TestParallelFailureTolerance:
+
+    @pytest.fixture
+    def target_node(self) -> ParallelFailureTolerance:
+        node = ParallelFailureTolerance(
+            options={"needed_successes": 2, "tolerate_failures": 0}
+        )
+        node.state = BTNodeState.IDLE
+        return node
+
+    def test_setup(
+        self,
+        target_node: ParallelFailureTolerance,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+        # Node has to be shutdown to call setup
+        target_node.state = BTNodeState.SHUTDOWN
+
+        result = target_node.setup()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.setup()]
+
+    def test_tick_success(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.state = BTNodeState.SUCCEEDED
+        mock_child_2.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == [mock.call.tick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        mock_child_3.state = BTNodeState.SUCCEEDED
+        mock_child_3.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [mock.call.tick(), mock.call.untick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == []
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        # The next tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        assert mock_child_1.mock_calls == [
+            mock.call.reset(),
+            mock.call.tick(),
+            mock.call.untick(),
+        ]
+        assert mock_child_2.mock_calls == [mock.call.reset()]
+        assert mock_child_3.mock_calls == [mock.call.reset()]
+
+    def test_tick_running(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+        for m_c in mock_children:
+            m_c.reset_mock()
+
+        # The second tick should NOT involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+    def test_tick_failure(
+        self,
+        target_node: Parallel,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.state = BTNodeState.FAILED
+        mock_child_2.tick.return_value = Ok(BTNodeState.FAILED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.tick(), mock.call.untick()]
+        assert mock_child_2.mock_calls == []
+        assert mock_child_3.mock_calls == [mock.call.tick(), mock.call.untick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        # The next tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [
+            mock.call.reset(),
+            mock.call.tick(),
+            mock.call.untick(),
+        ]
+        assert mock_child_2.mock_calls == [mock.call.reset()]
+        assert mock_child_3.mock_calls == [
+            mock.call.reset(),
+            mock.call.tick(),
+            mock.call.untick(),
+        ]
+
+    def test_untick(
+        self,
+        target_node: ParallelFailureTolerance,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.untick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.untick()]
+
+    def test_reset(
+        self,
+        target_node: ParallelFailureTolerance,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.reset()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset()]

--- a/ros_bt_py/tests/nodes/test_sequence.py
+++ b/ros_bt_py/tests/nodes/test_sequence.py
@@ -38,7 +38,7 @@ from ros_bt_py.nodes.sequence import MemorySequence, Sequence
 
 @pytest.fixture
 def mock_node() -> mock.NonCallableMagicMock:
-    mock_node = mock.NonCallableMagicMock(spec_set=Node)
+    mock_node = mock.NonCallableMagicMock(set=Node)
     mock_node.setup.return_value = Ok(BTNodeState.IDLE)
     mock_node.tick.return_value = Ok(BTNodeState.SUCCEEDED)
     mock_node.untick.return_value = Ok(BTNodeState.IDLE)

--- a/ros_bt_py/tests/nodes/test_sequence.py
+++ b/ros_bt_py/tests/nodes/test_sequence.py
@@ -1,0 +1,388 @@
+# Copyright 2025 FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the FZI Forschungszentrum Informatik nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import pytest
+import unittest.mock as mock
+
+from copy import deepcopy
+from result import Result, Ok, Err
+
+from ros_bt_py.helpers import BTNodeState
+from ros_bt_py.node import Node
+from ros_bt_py.nodes.sequence import MemorySequence, Sequence
+
+
+class TestSequence:
+
+    @pytest.fixture
+    def target_node(self) -> Sequence:
+        node = Sequence()
+        node.state = BTNodeState.IDLE
+        return node
+
+    @pytest.fixture
+    def mock_node(self) -> mock.NonCallableMagicMock:
+        mock_node = mock.NonCallableMagicMock(spec_set=Node)
+        mock_node.setup.return_value = Ok(BTNodeState.IDLE)
+        mock_node.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+        mock_node.untick.return_value = Ok(BTNodeState.IDLE)
+        mock_node.reset.return_value = Ok(BTNodeState.IDLE)
+        mock_node.shutdown.return_value = Ok(BTNodeState.SHUTDOWN)
+        return mock_node
+
+    def test_setup(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+        # Node has to be shutdown to call setup
+        target_node.state = BTNodeState.SHUTDOWN
+
+        result = target_node.setup()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.setup()]
+
+    def test_tick_success(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+        for m_c in mock_children:
+            m_c.reset_mock()
+
+        # The second tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
+
+    def test_tick_running(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == []
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == []
+
+    def test_tick_failure(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.FAILED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == [mock.call.untick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+
+        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
+
+    def test_untick(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.untick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.untick()]
+
+    def test_reset(
+        self,
+        target_node: Sequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.reset()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset()]
+
+
+class TestMemorySequence:
+
+    @pytest.fixture
+    def target_node(self) -> MemorySequence:
+        node = MemorySequence()
+        node.state = BTNodeState.IDLE
+        node.last_running_child = -1  # type: ignore
+        return node
+
+    @pytest.fixture
+    def mock_node(self) -> mock.NonCallableMagicMock:
+        mock_node = mock.NonCallableMagicMock(spec_set=Node)
+        mock_node.setup.return_value = Ok(BTNodeState.IDLE)
+        mock_node.tick.return_value = Ok(BTNodeState.SUCCEEDED)
+        mock_node.untick.return_value = Ok(BTNodeState.IDLE)
+        mock_node.reset.return_value = Ok(BTNodeState.IDLE)
+        mock_node.shutdown.return_value = Ok(BTNodeState.SHUTDOWN)
+        return mock_node
+
+    def test_setup(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+        # Node has to be shutdown to call setup
+        target_node.state = BTNodeState.SHUTDOWN
+
+        result = target_node.setup()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+        assert target_node.last_running_child == 0
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.setup()]
+
+    def test_tick_success(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+        assert target_node.last_running_child == -1
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.tick()]
+
+        for m_c in mock_children:
+            m_c.reset_mock()
+
+        # The second tick should also involve a reset on all child nodes
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.SUCCEEDED
+        assert target_node.state == BTNodeState.SUCCEEDED
+        assert target_node.last_running_child == 0
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset(), mock.call.tick()]
+
+    def test_tick_running(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.RUNNING)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+        assert target_node.last_running_child == 1
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == []
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.RUNNING
+        assert target_node.state == BTNodeState.RUNNING
+        assert target_node.last_running_child == 1
+
+        assert mock_child_1.mock_calls == []
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == []
+
+    def test_tick_failure(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_child_1 = deepcopy(mock_node)
+        mock_child_2 = deepcopy(mock_node)
+        mock_child_2.tick.return_value = Ok(BTNodeState.FAILED)
+        mock_child_3 = deepcopy(mock_node)
+
+        # We add node children directly to avoid node additional checks
+        target_node.children = [mock_child_1, mock_child_2, mock_child_3]  # type: ignore
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+        assert target_node.last_running_child == -1
+
+        assert mock_child_1.mock_calls == [mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.tick()]
+        assert mock_child_3.mock_calls == [mock.call.untick()]
+
+        mock_child_1.reset_mock()
+        mock_child_2.reset_mock()
+        mock_child_3.reset_mock()
+
+        result = target_node.tick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.FAILED
+        assert target_node.state == BTNodeState.FAILED
+        assert target_node.last_running_child == 0
+
+        assert mock_child_1.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_child_2.mock_calls == [mock.call.reset(), mock.call.tick()]
+        assert mock_child_3.mock_calls == [mock.call.reset(), mock.call.untick()]
+
+    def test_untick(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.untick()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+        assert target_node.last_running_child == 0
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.untick()]
+
+    def test_reset(
+        self,
+        target_node: MemorySequence,
+        mock_node: mock.NonCallableMagicMock,
+    ):
+        mock_children = [deepcopy(mock_node) for _ in range(3)]
+        # We add node children directly to avoid node additional checks
+        target_node.children = mock_children  # type: ignore
+
+        result = target_node.reset()
+        assert result.is_ok()
+        assert result.unwrap() == BTNodeState.IDLE
+        assert target_node.state == BTNodeState.IDLE
+        assert target_node.last_running_child == 0
+
+        for m_c in mock_children:
+            assert m_c.mock_calls == [mock.call.reset()]


### PR DESCRIPTION
This fixes the Fallback and MemoryFallback nodes reporting an incorrect state when being ticked.

Also adds pytest test cases for all seven flow control nodes, which test both the node state and whether child nodes are called appropriately.

Closes #212 
Closes #214 