### PR TITLE
Copy dictionary when setting msg fields

### DIFF
--- a/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
@@ -27,6 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """BT nodes to convert Dicts to ROS messages of a specific type."""
 
+from copy import deepcopy
 from typing import Dict, Optional
 
 from result import Result, Ok, Err
@@ -96,7 +97,7 @@ class MessageFromDict(Leaf):
             try:
                 set_message_fields(
                     message,
-                    self.inputs["dict"],
+                    deepcopy(self.inputs["dict"]),
                 )
                 self.outputs["message"] = message
             except (
@@ -177,7 +178,7 @@ class MessageFromConstDict(Leaf):
             # immediately call their respective callbacks?
             set_message_fields(
                 message,
-                self.options["dict"],
+                deepcopy(self.options["dict"]),
             )
             self.outputs["message"] = message
         except (TypeError, AttributeError) as ex:


### PR DESCRIPTION
Since the `set_message_fields` function from `rosidl_runtime_py.set_message` currently has the side-effect of altering the the source `dict` if it contains lists, we use `deepcopy` to preserve an unaltered version in our node inputs/options.

This bug is fixed from Kilted onwards.
https://github.com/ros2/rosidl_runtime_py/issues/33

Closes #213