### PR TITLE
Remove log message that is triggered frequently

### DIFF
--- a/ros_bt_py/ros_bt_py/node.py
+++ b/ros_bt_py/ros_bt_py/node.py
@@ -796,9 +796,6 @@ class Node(object, metaclass=NodeMeta):
         with report_state:
             error_result = None
             if self.state == BTNodeState.SHUTDOWN:
-                self.loginfo(
-                    "Not calling shutdown method, node has not been initialized yet"
-                )
                 self.state = BTNodeState.SHUTDOWN
                 # Call shutdown on all children - this should only set
                 # their state to shutdown


### PR DESCRIPTION
This log message is printed for every node in a tree, it can cause the server to lag by flooding the output.

Since this message can easily be triggered by calling for `shutdown` in a tree that was already shut down, we remove the log message to make the shutdown operation complete without delay/lag.