### PR TITLE
Bugfix: Set_options handle data wirings correctly

### DIFF
--- a/ros_bt_py/ros_bt_py/ros_nodes/subtree.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/subtree.py
@@ -116,9 +116,11 @@ class Subtree(Leaf):
             subtree_manager=self.nested_subtree_manager,
         )
 
-        load_result = self.load_subtree()
-        if load_result.is_err():
-            raise load_result.unwrap_err()
+        match self.load_subtree():
+            case Err(e):
+                raise e
+            case Ok(None):
+                pass
 
         if self.subtree_manager:
             self.subtree_manager.add_subtree_structure(


### PR DESCRIPTION
Fix the set_options service handler to properly unwire and rewire data connections.

This bug caused stale data to persist after a node had been edited and new data to not get passed along wirings, while the wirings still appeared as normal.