### PR TITLE
Bundle result library.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
         stages: [pre-commit]
         entry: ament_copyright
         language: system
+        exclude: "ros_bt_py/ros_bt_py/vendor/*"
       - id: ament_xmllint
         name: ament_xmllint
         description: Static code analysis of xml files.

--- a/THIRD_PARTY_NOTICE
+++ b/THIRD_PARTY_NOTICE
@@ -1,0 +1,5 @@
+This project includes software from the following third parties:
+
+result (https://github.com/rustedpy/result)
+Copyright (c) 2015-2020 Danilo Bargen and contributors
+Licensed under the MIT License. See ros_bt_py/ros_bt_py/vendor/result/LICENSE for details.

--- a/ros_bt_py/package.xml
+++ b/ros_bt_py/package.xml
@@ -28,7 +28,6 @@
   <!-- Python3 dependencies -->
   <depend>python3-toml</depend>
   <depend>python3-typeguard</depend>
-  <depend>python3-typing-extensions</depend>
   <depend>python3-jsonpickle</depend>
   <depend>python3-requests</depend>
   <depend>python3-simplejson</depend>

--- a/ros_bt_py/package.xml
+++ b/ros_bt_py/package.xml
@@ -32,7 +32,6 @@
   <depend>python3-requests</depend>
   <depend>python3-simplejson</depend>
   <depend>python3-packaging</depend>
-  <depend>result-pip</depend>
 
   <!-- Documentation dependencies -->
   <depend>python3-sphinx</depend>

--- a/ros_bt_py/package.xml
+++ b/ros_bt_py/package.xml
@@ -28,6 +28,7 @@
   <!-- Python3 dependencies -->
   <depend>python3-toml</depend>
   <depend>python3-typeguard</depend>
+  <depend>python3-typing-extensions</depend>
   <depend>python3-jsonpickle</depend>
   <depend>python3-requests</depend>
   <depend>python3-simplejson</depend>

--- a/ros_bt_py/ros_bt_py/migrate_tree_files.py
+++ b/ros_bt_py/ros_bt_py/migrate_tree_files.py
@@ -35,7 +35,7 @@ import yaml
 from importlib import metadata
 from packaging.version import Version
 from typing import Literal
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 from ros_bt_py.node import Node
 from ros_bt_py.custom_types import (
     FilePath,

--- a/ros_bt_py/ros_bt_py/node.py
+++ b/ros_bt_py/ros_bt_py/node.py
@@ -31,7 +31,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from types import ModuleType
 
-from result import Err, Ok, Result
+from ros_bt_py.vendor.result import Err, Ok, Result
 
 import abc
 import importlib

--- a/ros_bt_py/ros_bt_py/node_config.py
+++ b/ros_bt_py/ros_bt_py/node_config.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from typing import Any, Dict, Optional, List
-from result import Result, Err, Ok
+from ros_bt_py.vendor.result import Result, Err, Ok
 
 from ros_bt_py.exceptions import NodeConfigError
 

--- a/ros_bt_py/ros_bt_py/node_data.py
+++ b/ros_bt_py/ros_bt_py/node_data.py
@@ -28,7 +28,7 @@
 from typing import Any
 import rclpy
 import rclpy.logging
-from result import Err, Ok, Result
+from ros_bt_py.vendor.result import Err, Ok, Result
 
 from ros_bt_py.custom_types import (
     FilePath,

--- a/ros_bt_py/ros_bt_py/nodes/compare.py
+++ b/ros_bt_py/ros_bt_py/nodes/compare.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok
+from ros_bt_py.vendor.result import Result, Ok
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.helpers import BTNodeState
 

--- a/ros_bt_py/ros_bt_py/nodes/constant.py
+++ b/ros_bt_py/ros_bt_py/nodes/constant.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.exceptions import BehaviorTreeException

--- a/ros_bt_py/ros_bt_py/nodes/decorators.py
+++ b/ros_bt_py/ros_bt_py/nodes/decorators.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py_interfaces.msg import UtilityBounds
 

--- a/ros_bt_py/ros_bt_py/nodes/fallback.py
+++ b/ros_bt_py/ros_bt_py/nodes/fallback.py
@@ -32,7 +32,7 @@ from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.node import FlowControl, define_bt_node
 from ros_bt_py.node_config import NodeConfig
 
-from result import Result, Ok, Err, is_err
+from ros_bt_py.vendor.result import Result, Ok, Err, is_err
 
 
 @define_bt_node(

--- a/ros_bt_py/ros_bt_py/nodes/format.py
+++ b/ros_bt_py/ros_bt_py/nodes/format.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from string import Formatter
 import os
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/nodes/getters.py
+++ b/ros_bt_py/ros_bt_py/nodes/getters.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """BT nodes to get values from containers and other nodes."""
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.node import Decorator, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef

--- a/ros_bt_py/ros_bt_py/nodes/io.py
+++ b/ros_bt_py/ros_bt_py/nodes/io.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 from ros_bt_py.node import IO, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/nodes/list.py
+++ b/ros_bt_py/ros_bt_py/nodes/list.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 from ros_bt_py.node import Leaf, Decorator, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/nodes/maths.py
+++ b/ros_bt_py/ros_bt_py/nodes/maths.py
@@ -31,7 +31,7 @@ import uuid
 from typing import Optional, Dict
 from rclpy.node import Node
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.debug_manager import DebugManager
 from ros_bt_py.subtree_manager import SubtreeManager

--- a/ros_bt_py/ros_bt_py/nodes/parallel.py
+++ b/ros_bt_py/ros_bt_py/nodes/parallel.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import math
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py_interfaces.msg import UtilityBounds
 

--- a/ros_bt_py/ros_bt_py/nodes/passthrough_node.py
+++ b/ros_bt_py/ros_bt_py/nodes/passthrough_node.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef

--- a/ros_bt_py/ros_bt_py/nodes/random_number.py
+++ b/ros_bt_py/ros_bt_py/nodes/random_number.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import random
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.exceptions import BehaviorTreeException
 

--- a/ros_bt_py/ros_bt_py/nodes/sequence.py
+++ b/ros_bt_py/ros_bt_py/nodes/sequence.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from typing import List
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 from typeguard import typechecked
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/nodes/setters.py
+++ b/ros_bt_py/ros_bt_py/nodes/setters.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from copy import deepcopy
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig, OptionRef

--- a/ros_bt_py/ros_bt_py/nodes/wait.py
+++ b/ros_bt_py/ros_bt_py/nodes/wait.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from time import time
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.node import Leaf, define_bt_node
 from ros_bt_py.node_config import NodeConfig

--- a/ros_bt_py/ros_bt_py/ros_helpers.py
+++ b/ros_bt_py/ros_bt_py/ros_helpers.py
@@ -29,7 +29,7 @@ import inspect
 import array
 import uuid
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 import rclpy.logging
 from rclpy import action

--- a/ros_bt_py/ros_bt_py/ros_nodes/action.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/action.py
@@ -29,7 +29,7 @@ from threading import Lock
 import abc
 from typing import Optional, Any, Dict
 from enum import Enum
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 import rclpy

--- a/ros_bt_py/ros_bt_py/ros_nodes/enum.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/enum.py
@@ -28,7 +28,7 @@
 from typing import Optional, Dict
 from rclpy.node import Node
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 from ros_bt_py.debug_manager import DebugManager

--- a/ros_bt_py/ros_bt_py/ros_nodes/enum_switch.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/enum_switch.py
@@ -29,7 +29,7 @@
 from typing import Optional, Dict
 from rclpy.node import Node
 
-from result import Result, Ok, Err, is_err
+from ros_bt_py.vendor.result import Result, Ok, Err, is_err
 import uuid
 
 from ros_bt_py.debug_manager import DebugManager

--- a/ros_bt_py/ros_bt_py/ros_nodes/file.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/file.py
@@ -29,7 +29,7 @@
 from rclpy.utilities import ament_index_python
 import yaml
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/ros_nodes/message_converters.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/message_converters.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from typing import Optional, Dict
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 from ros_bt_py.custom_types import RosTopicType

--- a/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/messages_from_dict.py
@@ -30,7 +30,7 @@
 from copy import deepcopy
 from typing import Dict, Optional
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 from rclpy.node import Node

--- a/ros_bt_py/ros_bt_py/ros_nodes/param.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/param.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py_interfaces.msg import UtilityBounds
 from ros_bt_py.exceptions import BehaviorTreeException

--- a/ros_bt_py/ros_bt_py/ros_nodes/service.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/service.py
@@ -46,7 +46,7 @@ from ros_bt_py.ros_helpers import get_message_field_type
 
 import abc
 from typing import Any, Optional, Dict
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 

--- a/ros_bt_py/ros_bt_py/ros_nodes/subtree.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/subtree.py
@@ -28,7 +28,7 @@
 """BT node to encapsulate a part of a tree in a reusable subtree."""
 from typing import List, Optional, Dict
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 from rclpy.node import Node

--- a/ros_bt_py/ros_bt_py/ros_nodes/throttle.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/throttle.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.exceptions import BehaviorTreeException
 from ros_bt_py.helpers import BTNodeState

--- a/ros_bt_py/ros_bt_py/ros_nodes/time.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/time.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from builtin_interfaces.msg import Time
 

--- a/ros_bt_py/ros_bt_py/ros_nodes/topic.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/topic.py
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from typing import Dict, Optional
 
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 import uuid
 
 from rclpy.node import Node

--- a/ros_bt_py/ros_bt_py/subtree_manager.py
+++ b/ros_bt_py/ros_bt_py/subtree_manager.py
@@ -30,7 +30,7 @@ from threading import Lock
 from typing import Any, Dict, Mapping
 import uuid
 
-from result import Err, Ok, Result
+from ros_bt_py.vendor.result import Err, Ok, Result
 from typeguard import typechecked
 
 from ros_bt_py_interfaces.msg import TreeStructure, TreeState, TreeData

--- a/ros_bt_py/ros_bt_py/tree_manager.py
+++ b/ros_bt_py/ros_bt_py/tree_manager.py
@@ -35,7 +35,7 @@ from packaging.version import Version
 from threading import Thread, Lock, RLock
 from typing import Any, Callable, Dict, Optional, List, cast
 
-from result import Err, Ok, Result
+from ros_bt_py.vendor.result import Err, Ok, Result
 
 import rclpy
 import rclpy.logging

--- a/ros_bt_py/ros_bt_py/vendor/result/LICENSE
+++ b/ros_bt_py/ros_bt_py/vendor/result/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2015-2020 Danilo Bargen and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ros_bt_py/ros_bt_py/vendor/result/__init__.py
+++ b/ros_bt_py/ros_bt_py/vendor/result/__init__.py
@@ -1,3 +1,23 @@
+# Copyright (C) 2015-2020 Danilo Bargen and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from .result import (
     Err,
     Ok,

--- a/ros_bt_py/ros_bt_py/vendor/result/__init__.py
+++ b/ros_bt_py/ros_bt_py/vendor/result/__init__.py
@@ -1,0 +1,28 @@
+from .result import (
+    Err,
+    Ok,
+    OkErr,
+    Result,
+    UnwrapError,
+    as_async_result,
+    as_result,
+    is_ok,
+    is_err,
+    do,
+    do_async,
+)
+
+__all__ = [
+    "Err",
+    "Ok",
+    "OkErr",
+    "Result",
+    "UnwrapError",
+    "as_async_result",
+    "as_result",
+    "is_ok",
+    "is_err",
+    "do",
+    "do_async",
+]
+__version__ = "0.18.0.dev0"

--- a/ros_bt_py/ros_bt_py/vendor/result/result.py
+++ b/ros_bt_py/ros_bt_py/vendor/result/result.py
@@ -37,14 +37,10 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    TypeGuard,
 )
 
-from typing_extensions import TypeIs
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec, TypeAlias
-else:
-    from typing_extensions import ParamSpec, TypeAlias
+from typing import ParamSpec, TypeAlias
 
 
 T = TypeVar("T", covariant=True)  # Success type
@@ -546,7 +542,7 @@ def as_async_result(
     return decorator
 
 
-def is_ok(result: Result[T, E]) -> TypeIs[Ok[T]]:
+def is_ok(result: Result[T, E]) -> TypeGuard[Ok[T]]:
     """A type guard to check if a result is an Ok
 
     Usage:
@@ -563,7 +559,7 @@ def is_ok(result: Result[T, E]) -> TypeIs[Ok[T]]:
     return result.is_ok()
 
 
-def is_err(result: Result[T, E]) -> TypeIs[Err[E]]:
+def is_err(result: Result[T, E]) -> TypeGuard[Err[E]]:
     """A type guard to check if a result is an Err
 
     Usage:

--- a/ros_bt_py/ros_bt_py/vendor/result/result.py
+++ b/ros_bt_py/ros_bt_py/vendor/result/result.py
@@ -1,3 +1,22 @@
+# Copyright (C) 2015-2020 Danilo Bargen and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 from __future__ import annotations
 
 import functools
@@ -153,9 +172,7 @@ class Ok(Generic[T]):
         """
         return Ok(op(self._value))
 
-    async def map_async(
-        self, op: Callable[[T], Awaitable[U]]
-    ) -> Ok[U]:
+    async def map_async(self, op: Callable[[T], Awaitable[U]]) -> Ok[U]:
         """
         The contained result is `Ok`, so return the result of `op` with the
         original value passed in
@@ -511,7 +528,7 @@ def as_async_result(
         raise TypeError("as_result() requires one or more exception types")
 
     def decorator(
-        f: Callable[P, Awaitable[R]]
+        f: Callable[P, Awaitable[R]],
     ) -> Callable[P, Awaitable[Result[R, TBE]]]:
         """
         Decorator to turn a function into one that returns a ``Result``.
@@ -609,7 +626,7 @@ def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
 
 
 async def do_async(
-    gen: Union[Generator[Result[T, E], None, None], AsyncGenerator[Result[T, E], None]]
+    gen: Union[Generator[Result[T, E], None, None], AsyncGenerator[Result[T, E], None]],
 ) -> Result[T, E]:
     """Async version of do. Example:
 

--- a/ros_bt_py/ros_bt_py/vendor/result/result.py
+++ b/ros_bt_py/ros_bt_py/vendor/result/result.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+import functools
+import inspect
+import sys
+from warnings import warn
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Final,
+    Generator,
+    Generic,
+    Iterator,
+    Literal,
+    NoReturn,
+    Type,
+    TypeVar,
+    Union,
+)
+
+from typing_extensions import TypeIs
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec, TypeAlias
+else:
+    from typing_extensions import ParamSpec, TypeAlias
+
+
+T = TypeVar("T", covariant=True)  # Success type
+E = TypeVar("E", covariant=True)  # Error type
+U = TypeVar("U")
+F = TypeVar("F")
+P = ParamSpec("P")
+R = TypeVar("R")
+TBE = TypeVar("TBE", bound=BaseException)
+
+
+class Ok(Generic[T]):
+    """
+    A value that indicates success and which stores arbitrary data for the return value.
+    """
+
+    __match_args__ = ("ok_value",)
+    __slots__ = ("_value",)
+
+    def __iter__(self) -> Iterator[T]:
+        yield self._value
+
+    def __init__(self, value: T) -> None:
+        self._value = value
+
+    def __repr__(self) -> str:
+        return "Ok({})".format(repr(self._value))
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, Ok) and self._value == other._value
+
+    def __ne__(self, other: Any) -> bool:
+        return not (self == other)
+
+    def __hash__(self) -> int:
+        return hash((True, self._value))
+
+    def is_ok(self) -> Literal[True]:
+        return True
+
+    def is_err(self) -> Literal[False]:
+        return False
+
+    def ok(self) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def err(self) -> None:
+        """
+        Return `None`.
+        """
+        return None
+
+    @property
+    def value(self) -> T:
+        """
+        Return the inner value.
+
+        @deprecated Use `ok_value` or `err_value` instead. This method will be
+        removed in a future version.
+        """
+        warn(
+            "Accessing `.value` on Result type is deprecated, please use "
+            + "`.ok_value` or `.err_value` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value
+
+    @property
+    def ok_value(self) -> T:
+        """
+        Return the inner value.
+        """
+        return self._value
+
+    def expect(self, _message: str) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def expect_err(self, message: str) -> NoReturn:
+        """
+        Raise an UnwrapError since this type is `Ok`
+        """
+        raise UnwrapError(self, message)
+
+    def unwrap(self) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def unwrap_err(self) -> NoReturn:
+        """
+        Raise an UnwrapError since this type is `Ok`
+        """
+        raise UnwrapError(self, "Called `Result.unwrap_err()` on an `Ok` value")
+
+    def unwrap_or(self, _default: U) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def unwrap_or_else(self, op: object) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def unwrap_or_raise(self, e: object) -> T:
+        """
+        Return the value.
+        """
+        return self._value
+
+    def map(self, op: Callable[[T], U]) -> Ok[U]:
+        """
+        The contained result is `Ok`, so return `Ok` with original value mapped to
+        a new value using the passed in function.
+        """
+        return Ok(op(self._value))
+
+    async def map_async(
+        self, op: Callable[[T], Awaitable[U]]
+    ) -> Ok[U]:
+        """
+        The contained result is `Ok`, so return the result of `op` with the
+        original value passed in
+        """
+        return Ok(await op(self._value))
+
+    def map_or(self, default: object, op: Callable[[T], U]) -> U:
+        """
+        The contained result is `Ok`, so return the original value mapped to a new
+        value using the passed in function.
+        """
+        return op(self._value)
+
+    def map_or_else(self, default_op: object, op: Callable[[T], U]) -> U:
+        """
+        The contained result is `Ok`, so return original value mapped to
+        a new value using the passed in `op` function.
+        """
+        return op(self._value)
+
+    def map_err(self, op: object) -> Ok[T]:
+        """
+        The contained result is `Ok`, so return `Ok` with the original value
+        """
+        return self
+
+    def and_then(self, op: Callable[[T], Result[U, E]]) -> Result[U, E]:
+        """
+        The contained result is `Ok`, so return the result of `op` with the
+        original value passed in
+        """
+        return op(self._value)
+
+    async def and_then_async(
+        self, op: Callable[[T], Awaitable[Result[U, E]]]
+    ) -> Result[U, E]:
+        """
+        The contained result is `Ok`, so return the result of `op` with the
+        original value passed in
+        """
+        return await op(self._value)
+
+    def or_else(self, op: object) -> Ok[T]:
+        """
+        The contained result is `Ok`, so return `Ok` with the original value
+        """
+        return self
+
+    def inspect(self, op: Callable[[T], Any]) -> Result[T, E]:
+        """
+        Calls a function with the contained value if `Ok`. Returns the original result.
+        """
+        op(self._value)
+        return self
+
+    def inspect_err(self, op: Callable[[E], Any]) -> Result[T, E]:
+        """
+        Calls a function with the contained value if `Err`. Returns the original result.
+        """
+        return self
+
+
+class DoException(Exception):
+    """
+    This is used to signal to `do()` that the result is an `Err`,
+    which short-circuits the generator and returns that Err.
+    Using this exception for control flow in `do()` allows us
+    to simulate `and_then()` in the Err case: namely, we don't call `op`,
+    we just return `self` (the Err).
+    """
+
+    def __init__(self, err: Err[E]) -> None:
+        self.err = err
+
+
+class Err(Generic[E]):
+    """
+    A value that signifies failure and which stores arbitrary data for the error.
+    """
+
+    __match_args__ = ("err_value",)
+    __slots__ = ("_value",)
+
+    def __iter__(self) -> Iterator[NoReturn]:
+        def _iter() -> Iterator[NoReturn]:
+            # Exception will be raised when the iterator is advanced, not when it's created
+            raise DoException(self)
+            yield  # This yield will never be reached, but is necessary to create a generator
+
+        return _iter()
+
+    def __init__(self, value: E) -> None:
+        self._value = value
+
+    def __repr__(self) -> str:
+        return "Err({})".format(repr(self._value))
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, Err) and self._value == other._value
+
+    def __ne__(self, other: Any) -> bool:
+        return not (self == other)
+
+    def __hash__(self) -> int:
+        return hash((False, self._value))
+
+    def is_ok(self) -> Literal[False]:
+        return False
+
+    def is_err(self) -> Literal[True]:
+        return True
+
+    def ok(self) -> None:
+        """
+        Return `None`.
+        """
+        return None
+
+    def err(self) -> E:
+        """
+        Return the error.
+        """
+        return self._value
+
+    @property
+    def value(self) -> E:
+        """
+        Return the inner value.
+
+        @deprecated Use `ok_value` or `err_value` instead. This method will be
+        removed in a future version.
+        """
+        warn(
+            "Accessing `.value` on Result type is deprecated, please use "
+            + "`.ok_value` or '.err_value' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._value
+
+    @property
+    def err_value(self) -> E:
+        """
+        Return the inner value.
+        """
+        return self._value
+
+    def expect(self, message: str) -> NoReturn:
+        """
+        Raises an `UnwrapError`.
+        """
+        exc = UnwrapError(
+            self,
+            f"{message}: {self._value!r}",
+        )
+        if isinstance(self._value, BaseException):
+            raise exc from self._value
+        raise exc
+
+    def expect_err(self, _message: str) -> E:
+        """
+        Return the inner value
+        """
+        return self._value
+
+    def unwrap(self) -> NoReturn:
+        """
+        Raises an `UnwrapError`.
+        """
+        exc = UnwrapError(
+            self,
+            f"Called `Result.unwrap()` on an `Err` value: {self._value!r}",
+        )
+        if isinstance(self._value, BaseException):
+            raise exc from self._value
+        raise exc
+
+    def unwrap_err(self) -> E:
+        """
+        Return the inner value
+        """
+        return self._value
+
+    def unwrap_or(self, default: U) -> U:
+        """
+        Return `default`.
+        """
+        return default
+
+    def unwrap_or_else(self, op: Callable[[E], T]) -> T:
+        """
+        The contained result is ``Err``, so return the result of applying
+        ``op`` to the error value.
+        """
+        return op(self._value)
+
+    def unwrap_or_raise(self, e: Type[TBE]) -> NoReturn:
+        """
+        The contained result is ``Err``, so raise the exception with the value.
+        """
+        raise e(self._value)
+
+    def map(self, op: object) -> Err[E]:
+        """
+        Return `Err` with the same value
+        """
+        return self
+
+    async def map_async(self, op: object) -> Err[E]:
+        """
+        The contained result is `Ok`, so return the result of `op` with the
+        original value passed in
+        """
+        return self
+
+    def map_or(self, default: U, op: object) -> U:
+        """
+        Return the default value
+        """
+        return default
+
+    def map_or_else(self, default_op: Callable[[], U], op: object) -> U:
+        """
+        Return the result of the default operation
+        """
+        return default_op()
+
+    def map_err(self, op: Callable[[E], F]) -> Err[F]:
+        """
+        The contained result is `Err`, so return `Err` with original error mapped to
+        a new value using the passed in function.
+        """
+        return Err(op(self._value))
+
+    def and_then(self, op: object) -> Err[E]:
+        """
+        The contained result is `Err`, so return `Err` with the original value
+        """
+        return self
+
+    async def and_then_async(self, op: object) -> Err[E]:
+        """
+        The contained result is `Err`, so return `Err` with the original value
+        """
+        return self
+
+    def or_else(self, op: Callable[[E], Result[T, F]]) -> Result[T, F]:
+        """
+        The contained result is `Err`, so return the result of `op` with the
+        original value passed in
+        """
+        return op(self._value)
+
+    def inspect(self, op: Callable[[T], Any]) -> Result[T, E]:
+        """
+        Calls a function with the contained value if `Ok`. Returns the original result.
+        """
+        return self
+
+    def inspect_err(self, op: Callable[[E], Any]) -> Result[T, E]:
+        """
+        Calls a function with the contained value if `Err`. Returns the original result.
+        """
+        op(self._value)
+        return self
+
+
+# define Result as a generic type alias for use
+# in type annotations
+"""
+A simple `Result` type inspired by Rust.
+Not all methods (https://doc.rust-lang.org/std/result/enum.Result.html)
+have been implemented, only the ones that make sense in the Python context.
+"""
+Result: TypeAlias = Union[Ok[T], Err[E]]
+
+"""
+A type to use in `isinstance` checks.
+This is purely for convenience sake, as you could also just write `isinstance(res, (Ok, Err))
+"""
+OkErr: Final = (Ok, Err)
+
+
+class UnwrapError(Exception):
+    """
+    Exception raised from ``.unwrap_<...>`` and ``.expect_<...>`` calls.
+
+    The original ``Result`` can be accessed via the ``.result`` attribute, but
+    this is not intended for regular use, as type information is lost:
+    ``UnwrapError`` doesn't know about both ``T`` and ``E``, since it's raised
+    from ``Ok()`` or ``Err()`` which only knows about either ``T`` or ``E``,
+    not both.
+    """
+
+    _result: Result[object, object]
+
+    def __init__(self, result: Result[object, object], message: str) -> None:
+        self._result = result
+        super().__init__(message)
+
+    @property
+    def result(self) -> Result[Any, Any]:
+        """
+        Returns the original result.
+        """
+        return self._result
+
+
+def as_result(
+    *exceptions: Type[TBE],
+) -> Callable[[Callable[P, R]], Callable[P, Result[R, TBE]]]:
+    """
+    Make a decorator to turn a function into one that returns a ``Result``.
+
+    Regular return values are turned into ``Ok(return_value)``. Raised
+    exceptions of the specified exception type(s) are turned into ``Err(exc)``.
+    """
+    if not exceptions or not all(
+        inspect.isclass(exception) and issubclass(exception, BaseException)
+        for exception in exceptions
+    ):
+        raise TypeError("as_result() requires one or more exception types")
+
+    def decorator(f: Callable[P, R]) -> Callable[P, Result[R, TBE]]:
+        """
+        Decorator to turn a function into one that returns a ``Result``.
+        """
+
+        @functools.wraps(f)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Result[R, TBE]:
+            try:
+                return Ok(f(*args, **kwargs))
+            except exceptions as exc:
+                return Err(exc)
+
+        return wrapper
+
+    return decorator
+
+
+def as_async_result(
+    *exceptions: Type[TBE],
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[Result[R, TBE]]]]:
+    """
+    Make a decorator to turn an async function into one that returns a ``Result``.
+    Regular return values are turned into ``Ok(return_value)``. Raised
+    exceptions of the specified exception type(s) are turned into ``Err(exc)``.
+    """
+    if not exceptions or not all(
+        inspect.isclass(exception) and issubclass(exception, BaseException)
+        for exception in exceptions
+    ):
+        raise TypeError("as_result() requires one or more exception types")
+
+    def decorator(
+        f: Callable[P, Awaitable[R]]
+    ) -> Callable[P, Awaitable[Result[R, TBE]]]:
+        """
+        Decorator to turn a function into one that returns a ``Result``.
+        """
+
+        @functools.wraps(f)
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Result[R, TBE]:
+            try:
+                return Ok(await f(*args, **kwargs))
+            except exceptions as exc:
+                return Err(exc)
+
+        return async_wrapper
+
+    return decorator
+
+
+def is_ok(result: Result[T, E]) -> TypeIs[Ok[T]]:
+    """A type guard to check if a result is an Ok
+
+    Usage:
+
+    ``` python
+    r: Result[int, str] = get_a_result()
+    if is_ok(r):
+        r   # r is of type Ok[int]
+    elif is_err(r):
+        r   # r is of type Err[str]
+    ```
+
+    """
+    return result.is_ok()
+
+
+def is_err(result: Result[T, E]) -> TypeIs[Err[E]]:
+    """A type guard to check if a result is an Err
+
+    Usage:
+
+    ``` python
+    r: Result[int, str] = get_a_result()
+    if is_ok(r):
+        r   # r is of type Ok[int]
+    elif is_err(r):
+        r   # r is of type Err[str]
+    ```
+
+    """
+    return result.is_err()
+
+
+def do(gen: Generator[Result[T, E], None, None]) -> Result[T, E]:
+    """Do notation for Result (syntactic sugar for sequence of `and_then()` calls).
+
+
+    Usage:
+
+    ``` rust
+    // This is similar to
+    use do_notation::m;
+    let final_result = m! {
+        x <- Ok("hello");
+        y <- Ok(True);
+        Ok(len(x) + int(y) + 0.5)
+    };
+    ```
+
+    ``` rust
+    final_result: Result[float, int] = do(
+            Ok(len(x) + int(y) + 0.5)
+            for x in Ok("hello")
+            for y in Ok(True)
+        )
+    ```
+
+    NOTE: If you exclude the type annotation e.g. `Result[float, int]`
+    your type checker might be unable to infer the return type.
+    To avoid an error, you might need to help it with the type hint.
+    """
+    try:
+        return next(gen)
+    except DoException as e:
+        out: Err[E] = e.err  # type: ignore
+        return out
+    except TypeError as te:
+        # Turn this into a more helpful error message.
+        # Python has strange rules involving turning generators involving `await`
+        # into async generators, so we want to make sure to help the user clearly.
+        if "'async_generator' object is not an iterator" in str(te):
+            raise TypeError(
+                "Got async_generator but expected generator."
+                "See the section on do notation in the README."
+            )
+        raise te
+
+
+async def do_async(
+    gen: Union[Generator[Result[T, E], None, None], AsyncGenerator[Result[T, E], None]]
+) -> Result[T, E]:
+    """Async version of do. Example:
+
+    ``` python
+    final_result: Result[float, int] = await do_async(
+        Ok(len(x) + int(y) + z)
+            for x in await get_async_result_1()
+            for y in await get_async_result_2()
+            for z in get_sync_result_3()
+        )
+    ```
+
+    NOTE: Python makes generators async in a counter-intuitive way.
+
+    ``` python
+    # This is a regular generator:
+        async def foo(): ...
+        do(Ok(1) for x in await foo())
+    ```
+
+    ``` python
+    # But this is an async generator:
+        async def foo(): ...
+        async def bar(): ...
+        do(
+            Ok(1)
+            for x in await foo()
+            for y in await bar()
+        )
+    ```
+
+    We let users try to use regular `do()`, which works in some cases
+    of awaiting async values. If we hit a case like above, we raise
+    an exception telling the user to use `do_async()` instead.
+    See `do()`.
+
+    However, for better usability, it's better for `do_async()` to also accept
+    regular generators, as you get in the first case:
+
+    ``` python
+    async def foo(): ...
+        do(Ok(1) for x in await foo())
+    ```
+
+    Furthermore, neither mypy nor pyright can infer that the second case is
+    actually an async generator, so we cannot annotate `do_async()`
+    as accepting only an async generator. This is additional motivation
+    to accept either.
+    """
+    try:
+        if isinstance(gen, AsyncGenerator):
+            return await gen.__anext__()
+        else:
+            return next(gen)
+    except DoException as e:
+        out: Err[E] = e.err  # type: ignore
+        return out

--- a/ros_bt_py/setup.py
+++ b/ros_bt_py/setup.py
@@ -54,6 +54,8 @@ setup(
         "ros_bt_py",
         "ros_bt_py.nodes",
         "ros_bt_py.ros_nodes",
+        "ros_bt_py.vendor",
+        "ros_bt_py.vendor.result",
     ],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/ros_bt_py/tests/nodes/test_fallback.py
+++ b/ros_bt_py/tests/nodes/test_fallback.py
@@ -29,7 +29,7 @@ import pytest
 import unittest.mock as mock
 
 from copy import deepcopy
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.nodes.fallback import Fallback, MemoryFallback, NameSwitch

--- a/ros_bt_py/tests/nodes/test_parallel.py
+++ b/ros_bt_py/tests/nodes/test_parallel.py
@@ -29,7 +29,7 @@ import pytest
 import unittest.mock as mock
 
 from copy import deepcopy
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.node import Node

--- a/ros_bt_py/tests/nodes/test_sequence.py
+++ b/ros_bt_py/tests/nodes/test_sequence.py
@@ -29,7 +29,7 @@ import pytest
 import unittest.mock as mock
 
 from copy import deepcopy
-from result import Result, Ok, Err
+from ros_bt_py.vendor.result import Result, Ok, Err
 
 from ros_bt_py.helpers import BTNodeState
 from ros_bt_py.node import Node

--- a/ros_bt_py/tests/test_import.py
+++ b/ros_bt_py/tests/test_import.py
@@ -32,20 +32,19 @@ import pkgutil
 
 
 def import_module_from_package(package) -> None:
-    print(f"Beginning function: {package.__path__}")
-    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):
-        full_name = package.__name__ + "." + name
-        if is_pkg:
-            new_package = __import__(full_name, fromlist=[package.__name__])
-            import_module_from_package(new_package)
-        else:
-            try:
-                importlib.import_module(full_name)
-            except ModuleNotFoundError as exc:
-                if exc.name == "ros_bt_py.parameters":
-                    continue
-                else:
-                    raise exc
+    prefix = package.__name__ + "."
+
+    print(f"Walking package: {package.__name__} at {package.__path__}")
+
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__, prefix):
+        # name is already the full dotted path here because of the prefix argument
+        try:
+            print(f"Importing: {name}")
+            importlib.import_module(name)
+        except ModuleNotFoundError as exc:
+            if "ros_bt_py.parameters" in str(exc):
+                continue
+            raise exc
 
 
 class TestImport:


### PR DESCRIPTION
To avoid issues with installing `result` via pip in a ROS environment, I would suggest bundling it directly in ros_bt_py.
From a license point of view, this should be fine given the acknowledgement of the inclusion.