### PR TITLE
fix: handle service shutdown before first tick

### DIFF
--- a/ros_bt_py/ros_bt_py/ros_nodes/service.py
+++ b/ros_bt_py/ros_bt_py/ros_nodes/service.py
@@ -80,6 +80,7 @@ class ServiceBase(Leaf):
 
     _service_type: type
     _service_client: Optional[Client] = None
+    _service_request_future: Optional[Future] = None
 
     # Returns the service request message that should be send to the service.
     @abc.abstractmethod

--- a/ros_bt_py/tests/integration/ros_nodes_isolation/test_service.py
+++ b/ros_bt_py/tests/integration/ros_nodes_isolation/test_service.py
@@ -112,6 +112,20 @@ def test_tree_load(
 
 
 @pytest.mark.launch(fixture=sim_time_tree_node)
+def test_shutdown_before_first_tick(
+    tree_control_node: TreeControlNode,
+    time_control_node: TimeControlNode,
+):
+    assert tree_control_node.execute_tree(ControlTreeExecution.Request.SHUTDOWN).is_ok()
+    test_tree_load(tree_control_node, time_control_node)
+
+    shutdown_result = tree_control_node.execute_tree(
+        ControlTreeExecution.Request.SHUTDOWN
+    )
+    assert shutdown_result.is_ok()
+
+
+@pytest.mark.launch(fixture=sim_time_tree_node)
 @pytest.mark.dependency(depends=["test_tree_load"])
 def test_send_request(
     tree_control_node: TreeControlNode,


### PR DESCRIPTION
## Summary

Fixes #262.

- Initialize `ServiceBase._service_request_future` before setup.
- Prevent shutdown of a loaded service tree before its first tick from raising `AttributeError`.
- Add integration coverage for the regression.

## Validation

- `pytest -q ros_bt_py/tests/integration/ros_nodes_isolation/test_service.py`
- `pre-commit run --files ros_bt_py/ros_bt_py/ros_nodes/service.py ros_bt_py/tests/integration/ros_nodes_isolation/test_service.py`

Both passed.