### PR TITLE
fix: clear stale parent references when removing nodes

### DIFF
--- a/ros_bt_py/ros_bt_py/tree_edit_manager.py
+++ b/ros_bt_py/ros_bt_py/tree_edit_manager.py
@@ -75,7 +75,12 @@ class TreeEditManager(TreeExecManager):
             cycle_candidates = [starting_id]
             current_node = self.nodes[starting_id]
             while current_node.parent:
-                current_node = self.nodes[current_node.parent.node_id]
+                parent_id = current_node.parent.node_id
+                if parent_id not in self.nodes:
+                    # Editable trees can contain stale runtime references.
+                    safe_node_ids.extend(cycle_candidates)
+                    break
+                current_node = self.nodes[parent_id]
                 cycle_candidates.append(current_node.node_id)
                 if current_node.node_id == starting_id:
                     nodes_in_cycles.extend(cycle_candidates)
@@ -329,6 +334,14 @@ class TreeEditManager(TreeExecManager):
                     for child in self.nodes[parent_id].children
                     if child.node_id not in node_ids_to_remove
                 ]
+
+        for node in self.nodes.values():
+            if (
+                node.node_id not in node_ids_to_remove
+                and node.parent is not None
+                and node.parent.node_id in node_ids_to_remove
+            ):
+                node.parent = None
 
         for removed_id in node_ids_to_remove:
             if removed_id in self.nodes:

--- a/ros_bt_py/tests/test_tree_edit_manager.py
+++ b/ros_bt_py/tests/test_tree_edit_manager.py
@@ -65,6 +65,34 @@ def test_remove_node_repairs_a_forest():
     assert manager._children == {second.node_id: []}
 
 
+def test_remove_node_orphans_surviving_children():
+    parent = MemorySequence()
+    child = MemorySequence()
+    parent.add_child(child)
+    manager = make_manager(
+        [parent, child], {parent.node_id: [child.node_id], child.node_id: []}
+    )
+
+    response = manager.remove_node(
+        RemoveNode.Request(node_id=uuid_to_ros(parent.node_id), remove_children=False),
+        RemoveNode.Response(),
+    )
+
+    assert response.success
+    assert manager.nodes == {child.node_id: child}
+    assert child.parent is None
+    assert manager._children == {child.node_id: []}
+
+
+def test_find_nodes_in_cycles_ignores_dangling_parent():
+    node = MemorySequence()
+    deleted_parent = MemorySequence()
+    node.parent = deleted_parent
+    manager = make_manager([node], {node.node_id: []})
+
+    assert manager.find_nodes_in_cycles() == []
+
+
 def test_remove_children_terminates_for_a_cycle():
     first = MemorySequence()
     second = MemorySequence()


### PR DESCRIPTION
Closes #270

## Summary
- Clear surviving nodes' parent references when their parent is removed.
- Ignore dangling runtime parent references during cycle detection instead of raising `KeyError`.
- Add regression tests for orphan cleanup and dangling-parent cycle checks.

## Verification
- `pytest -q ros_bt_py/tests/test_tree_edit_manager.py` (4 passed)
- `pre-commit run --all-files` passed
- `colcon build --packages-up-to ros_bt_py` passed
- Full `colcon test --packages-select ros_bt_py` exceeded the local 120-second timeout without producing a result file; unrelated workspace test artifacts also report existing `bee_trees` formatting failures.