### PR TITLE
fix: handle invalid ROS message types

### DIFF
--- a/ros_bt_py/ros_bt_py/data_types.py
+++ b/ros_bt_py/ros_bt_py/data_types.py
@@ -1314,7 +1314,7 @@ class RosMessageType(RosContainer):
                     config = d
             config["message_type"] = message_type
             return Ok(config)
-        except AttributeError:
+        except (AttributeError, ImportError, ValueError):
             return Err(f"Cannot find message type '{msg.ros_msg_type}'")
 
     def is_compatible(

--- a/ros_bt_py/tests/test_data_types.py
+++ b/ros_bt_py/tests/test_data_types.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from ros_bt_py.data_types import get_iotype_for_msg
+from ros_bt_py_interfaces.msg import NodeDataType
+
+
+def test_invalid_ros_message_type_returns_error():
+    result = get_iotype_for_msg(
+        NodeDataType(
+            type_identifier=NodeDataType.ROS_INTERFACE_VALUE,
+            ros_msg_type="",
+        )
+    )
+
+    assert result.is_err()


### PR DESCRIPTION
## Summary
- Convert invalid serialized ROS message types into a node configuration error instead of propagating `ValueError` or import exceptions.
- Add regression coverage for an empty ROS message type.

## Verification
- `pytest -q tests/test_data_types.py`
- `pre-commit run --files ros_bt_py/data_types.py ros_bt_py/tests/test_data_types.py`

Fixes #236